### PR TITLE
meta-lxatac-software: rauc: add a date to the bundle version

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/lxatac-core-bundle-base.bb
+++ b/meta-lxatac-software/recipes-core/bundles/lxatac-core-bundle-base.bb
@@ -9,6 +9,9 @@ RAUC_BUNDLE_FORMAT = "verity"
 
 RAUC_BUNDLE_COMPATIBLE ?= "Demo Board"
 
+RAUC_BUNDLE_VERSION = "${DISTRO_VERSION}-${DATETIME}"
+RAUC_BUNDLE_VERSION[vardepsexclude] = "DATETIME"
+
 RAUC_BUNDLE_HOOKS[file] = "hook.sh"
 
 RAUC_BUNDLE_SLOTS ?= "rootfs bootloader"


### PR DESCRIPTION
RAUC allows us to query the bundle version string of remote bundles over dbus. This means we can pass a bundle URL to RAUC and it will respond with the bundle version string.
If we now include a version and date in the version string we can implement upgrade notifications based on it, á la 

> There is an update bundle available that is 30 days newer than your current version. Do you want to upgrade?

while only requiring new bundles to be placed on a known location on a dumb http server.

Rauc info call for reference:

```
$ rauc info …
Compatible: 	'lxatac-lxatac'
Version:    	'4.0-0-20221117084149'
Description:	'lxatac-core-bundle-base version 1.0-r0'
Build:      	'20221117084149'
Hooks:      	''
Bundle Format: 	verity
  Verity Salt: 	'6580e9effea832c3ff521bb8198fe4ad1c0b9c43e8d0bb24e153f1bc63241466'
  Verity Hash: 	'e0c51b9d15a0e8b3358962996de984d215a57d2120cd9a240695216afdd2975a'
  Verity Size: 	1732608
…
```