### PR TITLE
meta-lxatac-software: uhubctl: backport from meta-oe master

### DIFF
--- a/meta-lxatac-software/recipes-backport/uhubctl/uhubctl_2.5.0.bb
+++ b/meta-lxatac-software/recipes-backport/uhubctl/uhubctl_2.5.0.bb
@@ -1,0 +1,21 @@
+SUMMARY = "USB hub per-port power control"
+HOMEPAGE = "https://github.com/mvp/uhubctl"
+BUGTRACKER = "https://github.com/mvp/uhubctl/issues"
+DEPENDS = "libusb1"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRCREV = "20276ad5ced147d018e2b3fccedabd94597aa25e"
+SRC_URI = "git://github.com/mvp/${BPN};branch=master;protocol=https"
+S = "${WORKDIR}/git"
+
+# uhubctl gets its program version from "git describe". As we use the source
+# archive do reduce download size replace the call with our hardcoded version.
+do_configure:append() {
+    sed -i "s/^\(GIT_VERSION :=\).*$/\1 ${PV}/g" ${S}/Makefile
+}
+
+do_install () {
+    oe_runmake install DESTDIR=${D}
+}

--- a/meta-lxatac-software/recipes-support/uhubctl/uhubctl_%.bbappend
+++ b/meta-lxatac-software/recipes-support/uhubctl/uhubctl_%.bbappend
@@ -1,2 +1,0 @@
-SRCREV = "554a5c7eb35c060a973c1abcc592086f689c82d2"
-PR:append = "+gitr${SRCREV}"


### PR DESCRIPTION
`meta-oe` master now has version 2.5.0, which we want. No need to use a `_git.bb` version anymore. Copy the recipe from there instead.

Also move the recipe to a `recipes-backports` folder so we know we should re-check if it is still needed when upgrading yocto for the next time.

I don't know about the best practices when it comes to `recipe-*` folders, especially for backported recipes and if this goes against them.
Usually we name them just like the the folder the recipe came from, but this makes it hard to differentiate between backports (which should be re-evaluated with every yocto upgrade) and recipes created by us.
