### PR TITLE
meta-lxatac-software: labgrid: allow overriding USB ports in userconfig

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -1,11 +1,31 @@
 ## This file is overridden on update
-## Add your own exports to 'userconfig.yaml'
+## Add your own exports and config to 'userconfig.yaml'
 
+## Setup defaults
+## ==============
 
+## Use 115220 Baud as default DUT baud rate
+{% set serial = namespace(baud=115200) %}
+
+## External USB Ports of the LXA TAC
+{% set usb = namespace(ports=[
+        ('1',   'platform-5800d000.usb-usb-0:1.1'),
+        ('2',   'platform-5800d000.usb-usb-0:1.2'),
+        ('3',   'platform-5800d000.usb-usb-0:1.3')]) %}
+
+## Include user configuration
+## ==========================
+
+{% include 'userconfig.yaml' %}
+
+## Setup resources
+## ===============
+
+## UART available via the box connector on the TAC
 serial:
   RawSerialPort:
     port: /dev/ttySTM1
-    speed: 115200
+    speed: {{serial.baud}}
 
 ## FIXME: These should be accessed via the REST API at
 ## - /v1/output/out_0/asserted
@@ -24,11 +44,9 @@ dut_power:
     host: 'http://{{ hostname }}/v1/dut/powered/compat'
     index: '0'   # this is 'don't care'
 
-## LXATAC USB Ports
-{% for idx, sysfs in [
-        ('1',   'platform-5800d000.usb-usb-0:1.1'),
-        ('2',   'platform-5800d000.usb-usb-0:1.2'),
-        ('3',   'platform-5800d000.usb-usb-0:1.3')] %}
+## Set up USB ports after including user configuration to allow
+## e.g. hub configuration
+{% for idx, sysfs in usb.ports %}
 
 lxatac-usb-ports-p{{idx}}:
   USBSerialPort:
@@ -65,4 +83,3 @@ lxatac-usb-ports-p{{idx}}:
 {% endfor %}
 
 
-{% include 'userconfig.yaml' %}

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
@@ -3,6 +3,11 @@
 ## This file is included from configuration.yaml by a jinja2 include and can
 ## set some variables evaluated in configuration.yaml.
 
+## The userconfig.yaml file is migrated between rauc installs.
+## Use cp /etc/labgrid/userconfig.yaml.default /etc/labgrid/userconfig.yaml
+## to go back to the most recent defaults.
+
+
 ## Add your own exports here.
 
 ## Example for using an external USB to serial adapter and matching based

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
@@ -1,9 +1,32 @@
 ## This is the labgrid-exporter user-configuration.
+## Labgrid uses jinja2 templating for its config file.
+## This file is included from configuration.yaml by a jinja2 include and can
+## set some variables evaluated in configuration.yaml.
+
 ## Add your own exports here.
 
+## Example for using an external USB to serial adapter and matching based
+## on its serial number (instead of e.g. an USB path as below):
 ##example-group1-remote:
 ##  location: example-location-1-remote
 ##  USBSerialPort:
 ##    match:
 ##      'ID_SERIAL_SHORT': 'FTA8E2HP'
 ##    speed: 115200
+
+## Example for using a custom baud rate of 1M baud instead of the
+## 115200 baud default on the box connector:
+##{% serial.baud = 1000000 %}
+
+## Example for using an USB hub.
+## The usb.ports variable is used in configuration.yaml to set up common
+## USB peripheral matches on all listed ports.
+## This snippet removes direct matches on port three of the TAC and instead
+## matches on each port of a hub connected to port three:
+##{% set usb.ports = [
+##        ('1',   'platform-5800d000.usb-usb-0:1.1'),
+##        ('2',   'platform-5800d000.usb-usb-0:1.2'),
+##        ('3-1', 'platform-5800d000.usb-usb-0:1.3.1'),
+##        ('3-2', 'platform-5800d000.usb-usb-0:1.3.2'),
+##        ('3-3', 'platform-5800d000.usb-usb-0:1.3.3'),
+##        ('3-4', 'platform-5800d000.usb-usb-0:1.3.4')] %}

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
@@ -6,7 +6,12 @@ SRC_URI += " \
 "
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/userconfig.yaml ${D}${sysconfdir}/labgrid
+    # The userconfig.yaml is migrated via rauc hook between installs.
+    # Deploy a copy of the file so that users can go back to a default config
+    # or see what's new.
+    install -D -m 0644 ${WORKDIR}/userconfig.yaml ${D}${sysconfdir}/labgrid/userconfig.yaml
+    install -D -m 0644 ${WORKDIR}/userconfig.yaml ${D}${sysconfdir}/labgrid/userconfig.yaml.default
+
     install -D -m 0644 ${WORKDIR}/labgrid.conf ${D}${libdir}/tmpfiles.d/labgrid.conf
 }
 


### PR DESCRIPTION
This should make it easier to attach USB hubs to the TAC and getting the matches right.

I'm not too experienced with jinja2 so I've had some trouble working around the scoping rules (`set`ing a variable in a `include`d file does not have an effect on the file that did the `include`ing, but modifing the variable in another way does).
And preventing the output from my `usb_ports.pop` and `.extend` tricks from being rendered (that's what the `and '' and `or ''` are for).
Maybe you have some better idea.

@a3f could this be of any use to you?