### PR TITLE
meta-lxatac-software: tacd-webinterface: remove nodejs runtime dep.

### DIFF
--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -12,7 +12,7 @@ inherit npm
 
 # Remove the runtime dependency on nodejs. We only use it during the
 # build process to generate static html, js and css files.
-RDEPENDS:${PN}:append:class-target = ""
+RDEPENDS:${PN}:remove = "nodejs"
 
 WEBUI_INSTALL_DIR="${NPM_BUILD}/lib/node_modules/tacd-web"
 


### PR DESCRIPTION
It turns out that :append does not work as I had expected it to, as I have now learned from[1].
To remove an element that was :append-ed we actually need to use :remove.

With this patch nodejs and npm are actually no longer installed in the image.

[1]: https://summit.yoctoproject.org/yocto-project-summit-2022-05/talk/SCYYWD/