### PR TITLE
labgrid-exporter: fix indentation in configs

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -33,25 +33,25 @@ dut_power:
 lxatac-usb-ports-p{{idx}}:
   USBSerialPort:
     match:
-        '@ID_PATH': '{{sysfs}}'
+      '@ID_PATH': '{{sysfs}}'
   IMXUSBLoader:
     match:
-        'ID_PATH': '{{sysfs}}'
+      'ID_PATH': '{{sysfs}}'
   AndroidUSBFastboot:
     match:
-        'ID_PATH': '{{sysfs}}'
+      'ID_PATH': '{{sysfs}}'
   AlteraUSBBlaster:
     match:
-        'ID_PATH': '{{sysfs}}'
+      'ID_PATH': '{{sysfs}}'
   USBSDMuxDevice:
     match:
-        '@ID_PATH': '{{sysfs}}'
+      '@ID_PATH': '{{sysfs}}'
   LXAUSBMux:
     match:
-        '@ID_PATH': '{{sysfs}}'
+      '@ID_PATH': '{{sysfs}}'
   USBMassStorage:
     match:
-        '@ID_PATH': '{{sysfs}}'
+      '@ID_PATH': '{{sysfs}}'
 {% endfor %}
 
 

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/userconfig.yaml
@@ -2,8 +2,8 @@
 ## Add your own exports here.
 
 ##example-group1-remote:
-##    location: example-location-1-remote
-##    USBSerialPort:
-##      match:
-##        'ID_SERIAL_SHORT': 'FTA8E2HP'
-##      speed: 115200
+##  location: example-location-1-remote
+##  USBSerialPort:
+##    match:
+##      'ID_SERIAL_SHORT': 'FTA8E2HP'
+##    speed: 115200


### PR DESCRIPTION
Users tend to blindly copy from these files, so we should have the indentation correct.