### PR TITLE
labgrid-exporter: add USBVideo/USBAudioInput/USBDebugger resources

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -43,6 +43,9 @@ lxatac-usb-ports-p{{idx}}:
   AlteraUSBBlaster:
     match:
       'ID_PATH': '{{sysfs}}'
+  USBDebugger:
+    match:
+      'ID_PATH': '{{sysfs}}'
   USBSDMuxDevice:
     match:
       '@ID_PATH': '{{sysfs}}'
@@ -52,6 +55,13 @@ lxatac-usb-ports-p{{idx}}:
   USBMassStorage:
     match:
       '@ID_PATH': '{{sysfs}}'
+  USBVideo:
+    match:
+      '@ID_PATH': '{{sysfs}}'
+  USBAudioInput:
+    match:
+      '@ID_PATH': '{{sysfs}}'
+
 {% endfor %}
 
 


### PR DESCRIPTION
The required gstreamer plugins, gst-launch-1.0 and openocd are installed, so simply adding the new resources here is sufficient.

Note: The new resources already use the correct indentation. #19 fixes the indentation for the remaining resources. Mixing the indentation for the time being seems to work.