### PR TITLE
meta-lxatac-software: atftpd: fix /srv not being mounted due to atftpd

### DIFF
--- a/meta-lxatac-software/recipes-daemons/atftp/atftp_%.bbappend
+++ b/meta-lxatac-software/recipes-daemons/atftp/atftp_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://atftp-tmpfiles.conf"
+
+# On the TAC /srv is a separate partition, which does however fail to
+# mount if the tftp directory already exists.
+# Instead make sure that /srv/tftp is generated at runtime by tmpfiles.d.
+do_install:append() {
+    rmdir ${D}/srv/tftp ${D}/srv
+
+    install -D -m 0644 ${WORKDIR}/atftp-tmpfiles.conf ${D}${libdir}/tmpfiles.d/atftp.conf
+}
+
+FILES:${PN}d += "${libdir}/tmpfiles.d"

--- a/meta-lxatac-software/recipes-daemons/atftp/files/atftp-tmpfiles.conf
+++ b/meta-lxatac-software/recipes-daemons/atftp/files/atftp-tmpfiles.conf
@@ -1,0 +1,2 @@
+# Path			Mode	UID	GID	Age Argument
+d /srv/tftp		1775	root	root	2d


### PR DESCRIPTION
This fixes an issue introduced by #17, where `/srv` (which on the TAC is a separate partition) was not mounted on boot. This was caused by `/srv/tftp` existing in the image and thus `/srv` not being empty.

Make sure `/srv` is empty and `/srv/tftp` is created on boot.