### PR TITLE
meta-lxatac-software: rauc bundle: hook.sh fix lxa-iobus cache migration

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -7,6 +7,7 @@ function migrate () {
 		return
 	fi
 
+	mkdir -p "$(dirname "${RAUC_SLOT_MOUNT_POINT}"/"$1")"
 	cp -a "$1" "${RAUC_SLOT_MOUNT_POINT}/$1"
 }
 
@@ -20,7 +21,7 @@ case "$1" in
 		done
 		migrate /var/lib/chrony/drift
 		migrate /home/root/.bash_history
-		migrate /var/cache/lxa-iobus
+		migrate /var/cache/lxa-iobus/lss-cache
                 ;;
         *)
                 exit 1


### PR DESCRIPTION
The lxa-iobus server maintains a cache of IOBus node IDs it has seen before to speed up re-discovery of said nodes (known IDs are tried before performing a full LSS scan).

This cache is stored in `/var/cache/lxa-iobus/lss-cache`.

The migrate function in `hook.sh` only works on files, so it will not currently migrate the `lss-cache` inside of `/var/cache/lxa-iobus`. Fix that by pointing to the file directly. Also make sure the directory to migrate to exists on the system.

TODO:

- [x] I can not be trusted to write two correct lines of bash at a time. Make sure this actually does what it is supposed to by testing.