### PR TITLE
meta-lxatac-bsp: base-files: add fstab with explicit mount for /srv

### DIFF
--- a/meta-lxatac-bsp/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/base-files/base-files_%.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
 # Don't deploy an /etc/hostname. We have unique hostnames derived from factory
 # data passed from barebox to linux via systemd.hostname= and written to
 # /etc/hostname (if it does not exist) by lxatac-factory-data.

--- a/meta-lxatac-bsp/recipes-core/base-files/files/fstab
+++ b/meta-lxatac-bsp/recipes-core/base-files/files/fstab
@@ -1,0 +1,7 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+PARTUUID=491e0930-78b8-4da1-ba18-fb1fdc8b6515 /srv ext4 defaults           1  2
+


### PR DESCRIPTION
We have previously relied on `systemd-gpt-auto-generator` to automatically generate a `srv.mount` unit based on the partition type of the data partiton. The data partition is created on first boot by `systemd-repart`.

This results in `/srv` not being mounted on first boot as `systemd-generators` run very early in the boot process, long before `systemd-repart` had a chance to create the partition.

Add a `fstab` (mostly the default `fstab` from poky) that includes an explicit `/srv` mount.