### PR TITLE
meta-lxatac-software: lxatac-profile: fix wrong recipe description

### DIFF
--- a/meta-lxatac-software/recipes-core/lxatac-profile/lxatac-profile.bb
+++ b/meta-lxatac-software/recipes-core/lxatac-profile/lxatac-profile.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "PTX distro specific profile"
+DESCRIPTION = "Set up LG_CROSSBAR environment variable from labgrid env"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 


### PR DESCRIPTION
The recipe reads /etc/labgrid/environment and sets the `LG_CROSSBAR` environment variable based on it so that the labgrid client on the device can reach the coordinator.

Make sure the description reflects that.