### PR TITLE
meta-lxatac-software: chrony: use Linux Automation GmbH ntp pool zone

### DIFF
--- a/meta-lxatac-software/recipes-support/chrony/files/chrony.conf
+++ b/meta-lxatac-software/recipes-support/chrony/files/chrony.conf
@@ -1,9 +1,12 @@
-# Use public NTP servers from the pool.ntp.org project.
-# Please consider joining the pool project if possible by running your own
-# server(s).
-# If you are a vendor distributing a product using chrony, you *MUST*
-# read and comply with http://www.pool.ntp.org/vendors.html
-pool 0.openembedded.pool.ntp.org iburst
+# Use public NTP servers from the pool.ntp.org project using the
+# Linux Automation GmbH vendor zone.
+# The NTP pool project provides public servers for time synchronization
+# consider joining the pool[1] if you are interested in having a great time.
+# [1]: https://www.pool.ntp.org/join.html
+pool 0.linux-automation.pool.ntp.org iburst
+pool 1.linux-automation.pool.ntp.org iburst
+pool 2.linux-automation.pool.ntp.org iburst
+pool 3.linux-automation.pool.ntp.org iburst
 
 # Use time sources from DHCP.
 sourcedir /run/chrony-dhcp


### PR DESCRIPTION
The ntp pool project requires vendors to apply for a [vendor zone](https://www.pool.ntp.org/vendors.html) so that they can detect miss-behaving clients and contact the responsible parties, or ask heavy users for a contribution.

There is also a not about encouraging users to join the pool in the configuration file:

> If you have an open source ntpd implementation or an operating system including ntpd, we ask that you make a reference in the configuration file or documentation encouraging people to join the pool.

which I have also added.

TODO before removing the WIP mark:

* [x] Actually apply and be assigned a vendor zone
* [x] Update the vendor zone to the one actually assigned