### PR TITLE
meta-lxatac-software: tacd: upgrade to current main

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "08b911104ba2539cfc0b9e95cf160d81b6c8a494"
+SRCREV = "28451590d205395323c53ef17827510b1ea15ed7"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -4,7 +4,7 @@ SRC_URI = " \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "08b911104ba2539cfc0b9e95cf160d81b6c8a494"
+SRCREV = "28451590d205395323c53ef17827510b1ea15ed7"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This upgrade brings with it some improvements:

* The status of the UART RX/TX enable lines is no longer initially shown as off, even though it is actually on [4] and the buttons are labeled correctly [7].
* The DUT Power status OffDischarge is renamed to just Off and the previous behavior of Off is available as OffFloating [3]. OffFloating, being a high impedance state, shows some unexpected voltages in the web ui leading to non-ideal user experience. There is also now a filter on the DUT voltage and current measurements, but only for the decisions if the DUT should be powered off forcefully [2]. The values in the web interface are still unfiltered so we do not hide actual transients.
* The tac will now wait 10min instead of 1min before going into screensaver mode. This would have made the breakout game easteregg very annoying to exit, which is why it had to go [6].
* The tacd repo now has CI [9], which has generated some fallout [8] [10].

[2]: https://github.com/linux-automation/tacd/pull/2
[3]: https://github.com/linux-automation/tacd/pull/3
[4]: https://github.com/linux-automation/tacd/pull/4
[6]: https://github.com/linux-automation/tacd/pull/6
[7]: https://github.com/linux-automation/tacd/pull/7
[8]: https://github.com/linux-automation/tacd/pull/8
[9]: https://github.com/linux-automation/tacd/pull/9
[10]: https://github.com/linux-automation/tacd/pull/10