### PR TITLE
lxatac-core-image-base: add dfu-util and upgrade barebox-tools

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools_2023.02.1.bb
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools_2023.02.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "libusb1 libusb1-native lzop-native bison-native flex-native pkgconfig
 BBCLASSEXTEND = "native"
 
 SRC_URI = "http://barebox.org/download/barebox-${PV}.tar.bz2"
-SRC_URI[sha256sum] = "ddf7898075bec05e4865ce0f7a2ac19c2b1efaaa0d066eba1939494e25711d28"
+SRC_URI[sha256sum] = "0b207aae819b87cec6f388f99ee093757fbf24e27655f2045b7da63764a9f19b"
 
 S = "${WORKDIR}/barebox-${PV}"
 

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -30,6 +30,7 @@ IMAGE_INSTALL:append = "\
     crun \
     curl \
     devmem2 \
+    dfu-util \
     e2fsprogs-tune2fs \
     ethtool \
     evtest \

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -49,34 +49,34 @@ dut_power:
 {% for idx, sysfs in usb.ports %}
 
 lxatac-usb-ports-p{{idx}}:
-  USBSerialPort:
-    match:
-      '@ID_PATH': '{{sysfs}}'
-  IMXUSBLoader:
+  AlteraUSBBlaster:
     match:
       'ID_PATH': '{{sysfs}}'
   AndroidUSBFastboot:
     match:
       'ID_PATH': '{{sysfs}}'
-  AlteraUSBBlaster:
+  IMXUSBLoader:
     match:
       'ID_PATH': '{{sysfs}}'
-  USBDebugger:
-    match:
-      'ID_PATH': '{{sysfs}}'
-  USBSDMuxDevice:
-    match:
-      '@ID_PATH': '{{sysfs}}'
   LXAUSBMux:
     match:
       '@ID_PATH': '{{sysfs}}'
+  USBAudioInput:
+    match:
+      '@ID_PATH': '{{sysfs}}'
+  USBDebugger:
+    match:
+      'ID_PATH': '{{sysfs}}'
   USBMassStorage:
     match:
       '@ID_PATH': '{{sysfs}}'
-  USBVideo:
+  USBSDMuxDevice:
     match:
       '@ID_PATH': '{{sysfs}}'
-  USBAudioInput:
+  USBSerialPort:
+    match:
+      '@ID_PATH': '{{sysfs}}'
+  USBVideo:
     match:
       '@ID_PATH': '{{sysfs}}'
 

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -55,6 +55,9 @@ lxatac-usb-ports-p{{idx}}:
   AndroidUSBFastboot:
     match:
       'ID_PATH': '{{sysfs}}'
+  DFUDevice:
+    match:
+      'ID_PATH': '{{sysfs}}'
   IMXUSBLoader:
     match:
       'ID_PATH': '{{sysfs}}'


### PR DESCRIPTION
The `barebox-tools` upgrade allows us to, among other improvements, add support for i.MX8M Plus and Nano SoCs
in `imx-usb-loader`.

The addition of `dfu-util` allows us to bring up some SoCs from Boot Rom (like e.b. STM32MP1).

To do before this can be merged:

- [ ] Test both tools @a3f