### PR TITLE
labgrid-exporter: export FTDIs with multiple separate interfaces

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -79,7 +79,11 @@ lxatac-usb-ports-p{{idx}}:
   USBAudioInput:
     match:
       '@ID_PATH': '{{sysfs}}'
-
+## Extra USB Ports exported as separate interfaces on the same USB port
+{% for if in [ '1', '2', '3'] %}
+lxatac-usb-ports-p{{idx}}.{{if}}:
+   USBSerialPort:
+     match:
+       '@ID_PATH': '{{sysfs}}:1.{{if}}'
 {% endfor %}
-
-
+{% endfor %}


### PR DESCRIPTION
Some FTDIs pop up as multiple USB interfaces on the host system. Let's export there as well. This could've been done in the userconfig.yaml, but it's more convenient to just do this here centrally.

We'll just export the main interface and three more and assume 4 FTDIs is enough for everybody.