### PR TITLE
lxatac-core-image-base: add gstreamer1.0-plugins-bad-videoparsersbad

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -40,6 +40,7 @@ IMAGE_INSTALL:append = "\
     gdbserver \
     git \
     gstreamer1.0 \
+    gstreamer1.0-plugins-bad-videoparsersbad \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     htop \


### PR DESCRIPTION
We (and @tretter in particular) need the `h264parse` element to stream video from USB webcams with internal h264 encoder via labgrid.

I've looked at the image size increase:

    # Without gstreamer1.0-plugins-bad*
    -rw-r--r-- 1 lgo lgo 703M Mar  7 07:44 lxatac-core-image-base-lxatac-20230307064249.rootfs.tar

    # With gstreamer1.0-plugins-bad-videoparsersbad
    -rw-r--r-- 1 lgo lgo 703M Mar  7 07:54 lxatac-core-image-base-lxatac-20230307065243.rootfs.tar

    # With gstreamer1.0-plugins-bad
    -rw-r--r-- 1 lgo lgo 718M Mar  7 07:51 lxatac-core-image-base-lxatac-20230307064710.rootfs.tar

We should go with only `videoparsersbad` for now and see if we need other elements that warrant the size increase later.