### PR TITLE
meta-lxatac-software: android-tools: backport 10.0.0 from meta-oe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	url = https://git.yoctoproject.org/poky
 	branch = langdale
 
+[submodule "meta-selinux"]
+	path = meta-selinux
+	url = https://git.yoctoproject.org/meta-selinux

--- a/meta-lxatac-software/conf/templates/default/bblayers.conf.sample
+++ b/meta-lxatac-software/conf/templates/default/bblayers.conf.sample
@@ -19,4 +19,5 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-labgrid \
   ##OEROOT##/../meta-rauc \
   ##OEROOT##/../meta-virtualization \
+  ##OEROOT##/../meta-selinux \
   "

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libcrypto.mk-modifications-to-make-it-build-in-yocto.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libcrypto.mk-modifications-to-make-it-build-in-yocto.patch
@@ -1,0 +1,41 @@
+From 30193c177138551a9aa269ae249ed2800811b223 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:24:11 +0100
+Subject: [PATCH] libcrypto.mk: modifications to make it build in yocto
+ environment
+
+Adding an include file that is setting the common flags.
+
+Modified the build rule so that it outputs the binary and include
+to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ debian/libcrypto.mk | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/debian/libcrypto.mk b/debian/libcrypto.mk
+index 4c0268e..8b41056 100644
+--- a/debian/libcrypto.mk
++++ b/debian/libcrypto.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ include sources.mk
+ 
+ NAME = libcrypto
+@@ -26,6 +27,8 @@ CPPFLAGS += -Isrc/include -Isrc/crypto
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 -lpthread
+ 
+ build: $(SOURCES)
+-	mkdir --parents debian/out
+-	$(CC) $^ -o debian/out/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 debian/out/$(NAME).so
+\ No newline at end of file
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ 
++	mkdir --parents $(OUT_DIR)/usr/include
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DOPENSSL_NO_ASM
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r include/openssl $(OUT_DIR)/usr/include
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libext4_utils.mk-modifications-to-make-it-build-in-y.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libext4_utils.mk-modifications-to-make-it-build-in-y.patch
@@ -1,0 +1,54 @@
+From e284ceac2b10133ca916bbae8055f040607b506c Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:21:49 +0100
+Subject: [PATCH 1/2] libext4_utils.mk: modifications to make it build in yocto
+ environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary and header to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ debian/libext4_utils.mk | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/debian/libext4_utils.mk b/debian/libext4_utils.mk
+index 868e790..2e93158 100644
+--- a/debian/libext4_utils.mk
++++ b/debian/libext4_utils.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libext4_utils
+ 
+ ext4_utils_SOURCES := \
+@@ -17,14 +18,16 @@ CPPFLAGS += \
+             -Iext4_utils/include \
+             -Ilibfec/include \
+             -Isquashfs_utils \
+-            -I/usr/include/android \
++            -I/usr/include/android -I$(OUT_DIR)/usr/include \
+             -D_GNU_SOURCE -DFEC_NO_KLOG -DSQUASHFS_NO_KLOG -D_LARGEFILE64_SOURCE
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+            -lbase -lsparse -lselinux
+ 
+ build: $(SOURCES)
+-	mkdir --parents $(OUT_DIR)
+-	$(CC) $^ -o $(OUT_DIR)/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(OUT_DIR)/$(NAME).so
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r ext4_utils/include/* $(OUT_DIR)/usr/include/
++
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-patching-libundwind-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-patching-libundwind-to-build-in-yocto-environment.patch
@@ -1,0 +1,58 @@
+From d5fb34aef65b5c5472544e4f42ad777d8fa16ba9 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:41:52 +0100
+Subject: [PATCH] patching libundwind to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Passing the architecture details($CPU)from the recipe.
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/libunwind.mk | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/debian/libunwind.mk b/debian/libunwind.mk
+index 738b205..ada4ef9 100644
+--- a/debian/libunwind.mk
++++ b/debian/libunwind.mk
+@@ -1,4 +1,4 @@
+-include debian/detect_arch.mk
++include ../../rules_yocto.mk 
+ 
+ ARCH_SOURCES = is_fpreg.c \
+                regname.c \
+@@ -131,10 +131,12 @@ CFLAGS += -DHAVE_CONFIG_H -DNDEBUG -D_GNU_SOURCE -Werror -Wno-unused-parameter -
+ CPPFLAGS += -Iinclude -Isrc $($(CPU)_INCLUDES) -Idebian/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -lpthread -nostdlib -lc -lgcc -Ldebian/out -l7z
++           -lpthread -nostdlib -lc -lgcc -l7z
+ 
+ build: $(SOURCES)
+-	mkdir --parents debian/out
+-	ln -s /usr/lib/p7zip/7z.so debian/out/lib7z.so
+-	$(CC) $^ -o debian/out/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 debian/out/$(NAME).so
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ 
++	mkdir --parents $(OUT_DIR)/usr/include/android/libunwind
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -Wno-header-guard -Wno-absolute-value
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r include/* debian/include/* $(OUT_DIR)/usr/include/android/libunwind/
++
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0002-libfec-change-out_dir-in-makefile.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0002-libfec-change-out_dir-in-makefile.patch
@@ -1,0 +1,49 @@
+From 3be070a1fe2efa2877684f95c6a5643f76ee8bbc Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:32:11 +0100
+Subject: [PATCH 2/2] libfec: change out_dir in makefile
+
+---
+ debian/libfec.mk | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/debian/libfec.mk b/debian/libfec.mk
+index 1d48392..dea9316 100644
+--- a/debian/libfec.mk
++++ b/debian/libfec.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libfec
+ 
+ # copied from libfec/Android.bp
+@@ -12,20 +13,21 @@ CXXSOURCES := $(foreach source, $(filter %.cpp, $(SOURCES)), libfec/$(source))
+ CXXFLAGS += -fno-strict-aliasing -std=g++17
+ CPPFLAGS += \
+             -Iext4_utils/include \
+-            -Ilibfec/include \
++            -Ilibfec/include -I $(OUT_DIR)/usr/include \
+             -D_GNU_SOURCE -DFEC_NO_KLOG -D_LARGEFILE64_SOURCE
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -lbase -lsparse -lselinux
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	mkdir -p $(OUT_DIR)
+-	$(CXX) $^ -o $(OUT_DIR)/$(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(OUT_DIR)/$(NAME).so
++	mkdir -p $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libfec/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/adbd.mk
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/adbd.mk
@@ -1,0 +1,72 @@
+include ../../rules_yocto.mk
+NAME = adbd
+
+SOURCES = \
+	adb/daemon/main.cpp \
+	adb/daemon/auth.cpp \
+	adb/daemon/jdwp_service.cpp \
+	adb/daemon/file_sync_service.cpp \
+	adb/daemon/services.cpp \
+	adb/daemon/shell_service.cpp \
+	adb/daemon/remount_service.cpp \
+	adb/daemon/restart_service.cpp \
+	adb/daemon/reboot_service.cpp \
+	adb/daemon/framebuffer_service.cpp \
+	adb/daemon/set_verity_enable_state_service.cpp \
+	adb/shell_service_protocol.cpp \
+	adb/adb.cpp \
+	adb/adb_io.cpp \
+	adb/adb_listeners.cpp \
+	adb/adb_trace.cpp \
+	adb/adb_unique_fd.cpp \
+	adb/adb_utils.cpp \
+	adb/fdevent.cpp \
+	adb/services.cpp \
+	adb/sockets.cpp \
+	adb/socket_spec.cpp \
+	adb/sysdeps/errno.cpp \
+	adb/transport.cpp \
+	adb/transport_fd.cpp \
+	adb/transport_local.cpp \
+	adb/transport_usb.cpp \
+	adb/sysdeps_unix.cpp \
+	adb/sysdeps/posix/network.cpp \
+	adb/daemon/usb_legacy.cpp \
+	adb/daemon/usb_ffs.cpp \
+	adb/daemon/usb.cpp \
+	diagnose_usb/diagnose_usb.cpp \
+	libasyncio/AsyncIO.cpp \
+
+CXXFLAGS += -std=gnu++20
+CPPFLAGS += -Iinclude -Iadb -Ibase/include  -I$(OUT_DIR)/usr/include/ -Imkbootimg/include/bootimg -Ifs_mgr/include \
+	    -Ifs_mgr/include_fstab \
+            -DADB_VERSION='"$(DEB_VERSION)"' -D_GNU_SOURCE
+LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+           -lpthread -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -lbase -lcrypto_utils -lcrypto -lcutils -llog -lresolv
+
+PAGE_SIZE ?= 4096
+
+CXXFLAGS += -UADB_HOST
+CXXFLAGS += -DADB_HOST=0
+CXXFLAGS += -DALLOW_ADBD_DISABLE_VERITY
+CXXFLAGS += -DALLOW_ADBD_NO_AUTH
+CXXFLAGS += -DPLATFORM_TOOLS_VERSION='"28.0.2"'
+CXXFLAGS += -Idiagnose_usb/include
+CXXFLAGS += -Iadb/daemon/include
+CXXFLAGS += -Ilibasyncio/include
+CXXFLAGS += -Wno-c++11-narrowing
+CXXFLAGS += -DPAGE_SIZE=$(PAGE_SIZE)
+
+
+# -latomic should be the last library specified
+# https://github.com/android/ndk/issues/589
+ifneq ($(filter armel mipsel,$(DEB_HOST_ARCH)),)
+  LDFLAGS += -latomic
+endif
+
+build: $(SOURCES)
+	mkdir --parents ../../../android-tools/adbd
+	$(CXX) $^ -o ../../../android-tools/adbd/adbd $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+
+clean:
+	$(RM) $(OUT_DIR)/usr/bin/$(NAME)

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/android-tools-adbd.service
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/android-tools-adbd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Android Debug Bridge
+ConditionPathExists=/var/usb-debugging-enabled
+Before=android-system.service
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStartPre=-/usr/bin/android-gadget-setup adb
+ExecStart=/usr/bin/adbd
+
+[Install]
+WantedBy=basic.target

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Added-missing-headers.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Added-missing-headers.patch
@@ -1,0 +1,94 @@
+Description: Added missing headers causing compile errors
+Author: Umang Parmar <umangjparmar@gmail.com>
+Forwarded: not-needed
+
+--- a/adb/sysdeps/posix/network.cpp
++++ b/adb/sysdeps/posix/network.cpp
+@@ -22,6 +22,7 @@
+ #include <sys/socket.h>
+ 
+ #include <string>
++#include <cstring>
+ 
+ #include <android-base/logging.h>
+ #include <android-base/stringprintf.h>
+--- a/base/errors_unix.cpp
++++ b/base/errors_unix.cpp
+@@ -17,6 +17,7 @@
+ #include "android-base/errors.h"
+ 
+ #include <errno.h>
++#include <cstring>
+ 
+ namespace android {
+ namespace base {
+--- a/base/file.cpp
++++ b/base/file.cpp
+@@ -26,6 +26,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <cstring>
+ 
+ #include <memory>
+ #include <mutex>
+--- a/base/logging.cpp
++++ b/base/logging.cpp
+@@ -24,6 +24,7 @@
+ #include <inttypes.h>
+ #include <libgen.h>
+ #include <time.h>
++#include <cstring>
+ 
+ // For getprogname(3) or program_invocation_short_name.
+ #if defined(__ANDROID__) || defined(__APPLE__)
+--- a/libcutils/include/cutils/jstring.h
++++ b/libcutils/include/cutils/jstring.h
+@@ -19,6 +19,7 @@
+ 
+ #include <stdint.h>
+ #include <stddef.h>
++#include <uchar.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+--- a/libbacktrace/BacktraceMap.cpp
++++ b/libbacktrace/BacktraceMap.cpp
+@@ -21,6 +21,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <algorithm>
+ 
+ #include <log/log.h>
+ 
+--- a/demangle/Demangler.cpp
++++ b/demangle/Demangler.cpp
+@@ -20,6 +20,7 @@
+ #include <stack>
+ #include <string>
+ #include <vector>
++#include <cstring>
+ 
+ #include "Demangler.h"
+ 
+--- a/libbacktrace/UnwindStackMap.cpp
++++ b/libbacktrace/UnwindStackMap.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <algorithm>
+ 
+ #include <backtrace/BacktraceMap.h>
+ #include <unwindstack/Elf.h>
+--- a/adb/types.h
++++ b/adb/types.h
+@@ -17,6 +17,7 @@
+ #pragma once
+ 
+ #include <algorithm>
++#include <cstring>
+ #include <deque>
+ #include <memory>
+ #include <type_traits>

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Nonnull.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Nonnull.patch
@@ -1,0 +1,20 @@
+Description: Bring Clang's _Nonnull keyword to GCC
+Author: Kai-Chung Yan
+Forwarded: not-needed
+--- a/adb/sysdeps.h
++++ b/adb/sysdeps.h
+@@ -40,11 +40,12 @@
+ #include "sysdeps/network.h"
+ #include "sysdeps/stat.h"
+ 
++#define _Nonnull
++#define _Nullable
++
+ #ifdef _WIN32
+ 
+ // Clang-only nullability specifiers
+-#define _Nonnull
+-#define _Nullable
+ 
+ #include <ctype.h>
+ #include <direct.h>

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Vector-cast.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/Vector-cast.patch
@@ -1,0 +1,14 @@
+Description: Fix the wired error by GCC7 that fails to match the correct parent method.
+Author: Kai-Chung Yan
+Forwarded: not-needed
+--- a/libutils/include/utils/Vector.h
++++ b/libutils/include/utils/Vector.h
+@@ -256,7 +256,7 @@
+ 
+ template<class TYPE> inline
+ const Vector<TYPE>& Vector<TYPE>::operator = (const Vector<TYPE>& rhs) const {
+-    VectorImpl::operator = (static_cast<const VectorImpl&>(rhs));
++    VectorImpl::operator = (rhs);
+     return *this;
+ }
+ 

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/add-missing-headers.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/add-missing-headers.patch
@@ -1,0 +1,20 @@
+--- a/fs_mgr/liblp/reader.cpp
++++ b/fs_mgr/liblp/reader.cpp
+@@ -21,6 +21,7 @@
+ #include <unistd.h>
+ 
+ #include <functional>
++#include <cstring>
+ 
+ #include <android-base/file.h>
+ #include <android-base/unique_fd.h>
+--- a/fs_mgr/liblp/writer.cpp
++++ b/fs_mgr/liblp/writer.cpp
+@@ -20,6 +20,7 @@
+ #include <unistd.h>
+ 
+ #include <string>
++#include <cstring>
+ 
+ #include <android-base/file.h>
+ #include <android-base/unique_fd.h>

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-attribute-issue-with-gcc.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-attribute-issue-with-gcc.patch
@@ -1,0 +1,17 @@
+Description: remove clang-ism
+Forwarded: not-needed
+
+--- a/base/include/android-base/logging.h
++++ b/base/include/android-base/logging.h
+@@ -484,10 +484,7 @@
+ //       -Wno-user-defined-warnings to CPPFLAGS.
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wgcc-compat"
+-#define OSTREAM_STRING_POINTER_USAGE_WARNING \
+-    __attribute__((diagnose_if(true, "Unexpected logging of string pointer", "warning")))
+-inline std::ostream& operator<<(std::ostream& stream, const std::string* string_pointer)
+-    OSTREAM_STRING_POINTER_USAGE_WARNING {
++inline std::ostream& operator<<(std::ostream& stream, const std::string* string_pointer) {
+   return stream << static_cast<const void*>(string_pointer);
+ }
+ #pragma clang diagnostic pop

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-build-on-non-x86.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-build-on-non-x86.patch
@@ -1,0 +1,24 @@
+Description: non-x86 arches do not have PAGE_SIZE
+Forwarded: not-needed
+--- a/base/cmsg.cpp
++++ b/base/cmsg.cpp
+@@ -33,7 +33,8 @@
+                                  const std::vector<int>& fds) {
+   size_t cmsg_space = CMSG_SPACE(sizeof(int) * fds.size());
+   size_t cmsg_len = CMSG_LEN(sizeof(int) * fds.size());
+-  if (cmsg_space >= PAGE_SIZE) {
++  size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
++  if (cmsg_space >= pagesize) {
+     errno = ENOMEM;
+     return -1;
+   }
+@@ -75,7 +76,8 @@
+   fds->clear();
+ 
+   size_t cmsg_space = CMSG_SPACE(sizeof(int) * max_fds);
+-  if (cmsg_space >= PAGE_SIZE) {
++  size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
++  if (cmsg_space >= pagesize) {
+     errno = ENOMEM;
+     return -1;
+   }

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gcc-11-ftbfs.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gcc-11-ftbfs.patch
@@ -1,0 +1,22 @@
+Index: android-platform-system-core/libunwindstack/include/unwindstack/DwarfMemory.h
+===================================================================
+--- android-platform-system-core.orig/libunwindstack/include/unwindstack/DwarfMemory.h
++++ android-platform-system-core/libunwindstack/include/unwindstack/DwarfMemory.h
+@@ -29,7 +29,7 @@ class DwarfMemory {
+   DwarfMemory(Memory* memory) : memory_(memory) {}
+   virtual ~DwarfMemory() = default;
+ 
+-  bool ReadBytes(void* dst, size_t num_bytes);
++  bool ReadBytes(void* dst, std::size_t num_bytes);
+ 
+   template <typename SignedType>
+   bool ReadSigned(uint64_t* value);
+@@ -39,7 +39,7 @@ class DwarfMemory {
+   bool ReadSLEB128(int64_t* value);
+ 
+   template <typename AddressType>
+-  size_t GetEncodedSize(uint8_t encoding);
++  std::size_t GetEncodedSize(uint8_t encoding);
+ 
+   bool AdjustEncodedValue(uint8_t encoding, uint64_t* value);
+ 

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gettid-exception-declaration.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gettid-exception-declaration.patch
@@ -1,0 +1,22 @@
+--- a/libcutils/include/cutils/threads.h
++++ b/libcutils/include/cutils/threads.h
+@@ -33,7 +33,7 @@
+ // Deprecated: use android::base::GetThreadId instead, which doesn't truncate on Mac/Windows.
+ //
+ 
+-extern pid_t gettid();
++extern pid_t gettid(void) __THROW;
+ 
+ //
+ // Deprecated: use `_Thread_local` in C or `thread_local` in C++.
+--- a/libcutils/threads.cpp
++++ b/libcutils/threads.cpp
+@@ -33,7 +33,7 @@
+ 
+ // No definition needed for Android because we'll just pick up bionic's copy.
+ #ifndef __ANDROID__
+-pid_t gettid() {
++pid_t gettid(void) __THROW {
+ #if defined(__APPLE__)
+   uint64_t tid;
+   pthread_threadid_np(NULL, &tid);

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gnu-hurd.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/fix-gnu-hurd.patch
@@ -1,0 +1,150 @@
+From: Roger Shimizu <rosh@debian.org>
+Date: Sun, 10 Jan 2021 19:03:17 +0900
+Subject: Fix GNU/Hurd
+
+Reference:
+- https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
+
+Closes: #915762
+---
+ base/cmsg.cpp                  |  2 ++
+ base/threads.cpp               |  2 +-
+ libcutils/ashmem-host.cpp      | 20 +++++++++++++++++---
+ libcutils/canned_fs_config.cpp |  2 +-
+ libcutils/fs.cpp               | 20 ++++++++++++++++----
+ 5 files changed, 37 insertions(+), 9 deletions(-)
+
+diff --git a/base/cmsg.cpp b/base/cmsg.cpp
+index ae5bb16..e5ec321 100644
+--- a/base/cmsg.cpp
++++ b/base/cmsg.cpp
+@@ -20,7 +20,9 @@
+ #include <fcntl.h>
+ #include <stdlib.h>
+ #include <sys/socket.h>
++#ifndef __GNU__
+ #include <sys/user.h>
++#endif
+ 
+ #include <memory>
+ 
+diff --git a/base/threads.cpp b/base/threads.cpp
+index 48f6197..19cc293 100644
+--- a/base/threads.cpp
++++ b/base/threads.cpp
+@@ -47,7 +47,7 @@ uint64_t GetThreadId() {
+ }  // namespace base
+ }  // namespace android
+ 
+-#if defined(__GLIBC__)
++#if defined(__GLIBC__) && !defined(__GNU__)
+ int tgkill(int tgid, int tid, int sig) {
+   return syscall(__NR_tgkill, tgid, tid, sig);
+ }
+diff --git a/libcutils/ashmem-host.cpp b/libcutils/ashmem-host.cpp
+index 32446d4..83dd622 100644
+--- a/libcutils/ashmem-host.cpp
++++ b/libcutils/ashmem-host.cpp
+@@ -31,16 +31,30 @@
+ #include <sys/types.h>
+ #include <time.h>
+ #include <unistd.h>
++#include <stdint.h>
+ 
+ #include <utils/Compat.h>
+ 
+ int ashmem_create_region(const char* /*ignored*/, size_t size) {
+-    char pattern[PATH_MAX];
+-    snprintf(pattern, sizeof(pattern), "/tmp/android-ashmem-%d-XXXXXXXXX", getpid());
++    char *pattern;
++    size_t pattern_size = 128;
++    while(1) {
++        pattern = (char*) malloc(pattern_size);
++        if(snprintf(pattern, strlen(pattern), "/tmp/android-ashmem-%d-XXXXXXXXX", getpid()) < pattern_size)
++            break;
++        free(pattern);
++        pattern_size *= 2;
++        if(pattern_size >= INT_LEAST16_MAX)
++            return -1;
++    }
+     int fd = mkstemp(pattern);
+-    if (fd == -1) return -1;
++    if (fd == -1) {
++        free(pattern);
++        return -1;
++	}
+ 
+     unlink(pattern);
++    free(pattern);
+ 
+     if (TEMP_FAILURE_RETRY(ftruncate(fd, size)) == -1) {
+       close(fd);
+diff --git a/libcutils/canned_fs_config.cpp b/libcutils/canned_fs_config.cpp
+index 2772ef0..1e41f37 100644
+--- a/libcutils/canned_fs_config.cpp
++++ b/libcutils/canned_fs_config.cpp
+@@ -42,7 +42,7 @@ static int path_compare(const void* a, const void* b) {
+ }
+ 
+ int load_canned_fs_config(const char* fn) {
+-    char buf[PATH_MAX + 200];
++    char buf[1024];
+     FILE* f;
+ 
+     f = fopen(fn, "r");
+diff --git a/libcutils/fs.cpp b/libcutils/fs.cpp
+index ef85acc..2884835 100644
+--- a/libcutils/fs.cpp
++++ b/libcutils/fs.cpp
+@@ -33,6 +33,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdint.h>
+ 
+ #include <log/log.h>
+ 
+@@ -150,15 +151,24 @@ fail:
+ }
+ 
+ int fs_write_atomic_int(const char* path, int value) {
+-    char temp[PATH_MAX];
+-    if (snprintf(temp, PATH_MAX, "%s.XXXXXX", path) >= PATH_MAX) {
+-        ALOGE("Path too long");
+-        return -1;
++    char *temp;
++    size_t temp_size = 128;
++    while(1) {
++        temp = (char*) malloc(temp_size);
++        if(snprintf(temp, strlen(temp), "%s.XXXXXX", path) < temp_size)
++            break;
++        free(temp);
++        temp_size *= 2;
++        if(temp_size >= INT_LEAST16_MAX) {
++            ALOGE("Path too long");
++            return -1;
++        }
+     }
+ 
+     int fd = TEMP_FAILURE_RETRY(mkstemp(temp));
+     if (fd == -1) {
+         ALOGE("Failed to open %s: %s", temp, strerror(errno));
++        free(temp);
+         return -1;
+     }
+ 
+@@ -182,12 +192,14 @@ int fs_write_atomic_int(const char* path, int value) {
+         goto fail_closed;
+     }
+ 
++    free(temp);
+     return 0;
+ 
+ fail:
+     close(fd);
+ fail_closed:
+     unlink(temp);
++    free(temp);
+     return -1;
+ }
+ 

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/hard-code-build-number.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/hard-code-build-number.patch
@@ -1,0 +1,43 @@
+Description: just hard code rather than deal with circular deps
+Forwarded: not-needed
+--- a/adb/adb.cpp
++++ b/adb/adb.cpp
+@@ -44,8 +44,6 @@
+ #include <android-base/parsenetaddress.h>
+ #include <android-base/stringprintf.h>
+ #include <android-base/strings.h>
+-#include <build/version.h>
+-#include <platform_tools_version.h>
+ 
+ #include "adb_auth.h"
+ #include "adb_io.h"
+@@ -69,7 +67,7 @@
+         "Version %s-%s\n"
+         "Installed as %s\n",
+         ADB_VERSION_MAJOR, ADB_VERSION_MINOR, ADB_SERVER_VERSION,
+-        PLATFORM_TOOLS_VERSION, android::build::GetBuildNumber().c_str(),
++        PLATFORM_TOOLS_VERSION, "debian",
+         android::base::GetExecutablePath().c_str());
+ }
+ 
+--- a/fastboot/fastboot.cpp
++++ b/fastboot/fastboot.cpp
+@@ -58,9 +58,7 @@
+ #include <android-base/stringprintf.h>
+ #include <android-base/strings.h>
+ #include <android-base/unique_fd.h>
+-#include <build/version.h>
+ #include <liblp/liblp.h>
+-#include <platform_tools_version.h>
+ #include <sparse/sparse.h>
+ #include <ziparchive/zip_archive.h>
+ 
+@@ -1680,7 +1678,7 @@
+                 setvbuf(stdout, nullptr, _IONBF, 0);
+                 setvbuf(stderr, nullptr, _IONBF, 0);
+             } else if (name == "version") {
+-                fprintf(stdout, "fastboot version %s-%s\n", PLATFORM_TOOLS_VERSION, android::build::GetBuildNumber().c_str());
++                fprintf(stdout, "fastboot version %s-%s\n", PLATFORM_TOOLS_VERSION, "debian");
+                 fprintf(stdout, "Installed as %s\n", android::base::GetExecutablePath().c_str());
+                 return 0;
+ #if !defined(_WIN32)

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/libusb-header-path.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/libusb-header-path.patch
@@ -1,0 +1,16 @@
+Description: libusb.h comes from different location
+Author: Umang Parmar <umangjparmar@gmail.com>
+Forwarded: not-needed
+Last-Update: 2018-05-26
+
+--- a/adb/client/usb_libusb.cpp
++++ b/adb/client/usb_libusb.cpp
+@@ -30,7 +30,7 @@
+ #include <thread>
+ #include <unordered_map>
+ 
+-#include <libusb/libusb.h>
++#include <libusb-1.0/libusb.h>
+ 
+ #include <android-base/file.h>
+ #include <android-base/logging.h>

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/move-log-file-to-proper-dir.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/move-log-file-to-proper-dir.patch
@@ -1,0 +1,18 @@
+Description: Update log file directory.
+Author: Umang Parmar <umangjparmar@gmail.com>
+Last Updated: 2018-05-17
+
+--- a/adb/adb_utils.cpp
++++ b/adb/adb_utils.cpp
+@@ -339,6 +339,11 @@
+ 
+     return temp_path_utf8 + log_name;
+ #else
++    std::string log_dir = android::base::StringPrintf("/run/user/%u/adb.log", getuid());
++    struct stat st = {0};
++    if (stat(log_dir.c_str(), &st) == 0) {
++      return log_dir;
++    }
+     const char* tmp_dir = getenv("TMPDIR");
+     if (tmp_dir == nullptr) tmp_dir = "/tmp";
+     return android::base::StringPrintf("%s/adb.%u.log", tmp_dir, getuid());

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/simg_dump-python3.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/simg_dump-python3.patch
@@ -1,0 +1,62 @@
+Description: Port simg_dump to Python 3.
+Author: Antonio Russo <antonio.e.russo@gmail.com>
+Forwarded: no
+Last-Update: 2019-01-05
+Origin: https://bugs.debian.org/945646
+
+---
+Index: android-platform-system-core/libsparse/simg_dump.py
+===================================================================
+--- android-platform-system-core.orig/libsparse/simg_dump.py
++++ android-platform-system-core/libsparse/simg_dump.py
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python3
+ 
+ # Copyright (C) 2012 The Android Open Source Project
+ #
+@@ -14,7 +14,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-from __future__ import print_function
++
+ import csv
+ import getopt
+ import hashlib
+@@ -47,7 +47,7 @@ def main():
+     opts, args = getopt.getopt(sys.argv[1:],
+                                "vsc:",
+                                ["verbose", "showhash", "csvfile"])
+-  except getopt.GetoptError, e:
++  except getopt.GetoptError as e:
+     print(e)
+     usage(me)
+   for o, a in opts:
+@@ -66,7 +66,7 @@ def main():
+     usage(me)
+ 
+   if csvfilename:
+-    csvfile = open(csvfilename, "wb")
++    csvfile = open(csvfilename, "w", newline='')
+     csvwriter = csv.writer(csvfile)
+ 
+   output = verbose or csvfilename or showhash
+@@ -121,7 +121,7 @@ def main():
+                           "output offset", "output blocks", "type", "hash"])
+ 
+     offset = 0
+-    for i in xrange(1, total_chunks + 1):
++    for i in range(1, total_chunks + 1):
+       header_bin = FH.read(12)
+       header = struct.unpack("<2H2I", header_bin)
+       chunk_type = header[0]
+@@ -160,7 +160,7 @@ def main():
+           if showhash:
+             h = hashlib.sha1()
+             data = fill_bin * (blk_sz / 4);
+-            for block in xrange(chunk_sz):
++            for block in range(chunk_sz):
+               h.update(data)
+             curhash = h.hexdigest()
+       elif chunk_type == 0xCAC3:

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/stdatomic.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/stdatomic.patch
@@ -1,0 +1,74 @@
+Description: Fix incompatibility between <stdatomic.h> and <atomic>
+ This 2 headers combined will cause errors for both GCC and Clang. This patch
+ makes sure only one of them is present at any time.
+Bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932
+Bug: https://reviews.llvm.org/D45470
+--- a/libcutils/include/cutils/trace.h
++++ b/libcutils/include/cutils/trace.h
+@@ -18,7 +18,14 @@
+ #define _LIBS_CUTILS_TRACE_H
+ 
+ #include <inttypes.h>
++#ifdef __cplusplus
++#include <atomic>
++using std::atomic_bool;
++using std::atomic_load_explicit;
++using std::memory_order_acquire;
++#else
+ #include <stdatomic.h>
++#endif
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <stdio.h>
+--- a/libcutils/include/cutils/atomic.h
++++ b/libcutils/include/cutils/atomic.h
+@@ -19,7 +19,23 @@
+ 
+ #include <stdint.h>
+ #include <sys/types.h>
++#ifdef __cplusplus
++#include <atomic>
++using std::atomic_compare_exchange_strong_explicit;
++using std::atomic_fetch_add_explicit;
++using std::atomic_fetch_or_explicit;
++using std::atomic_fetch_sub_explicit;
++using std::atomic_int_least32_t;
++using std::atomic_load_explicit;
++using std::atomic_store_explicit;
++using std::atomic_thread_fence;
++using std::memory_order::memory_order_acquire;
++using std::memory_order::memory_order_relaxed;
++using std::memory_order::memory_order_release;
++using std::memory_order::memory_order_seq_cst;
++#else
+ #include <stdatomic.h>
++#endif
+ 
+ #ifndef ANDROID_ATOMIC_INLINE
+ #define ANDROID_ATOMIC_INLINE static inline
+--- a/liblog/logger.h
++++ b/liblog/logger.h
+@@ -16,7 +16,13 @@
+ 
+ #pragma once
+ 
++#ifdef __cplusplus
++#include <atomic>
++using std::atomic_int;
++using std::atomic_uintptr_t;
++#else
+ #include <stdatomic.h>
++#endif
+ #include <stdbool.h>
+ 
+ #include <cutils/list.h>
+--- a/liblog/logger_write.cpp
++++ b/liblog/logger_write.cpp
+@@ -15,7 +15,6 @@
+  */
+ 
+ #include <errno.h>
+-#include <stdatomic.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/time.h>

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/throw-exception-on-unknown-os.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/throw-exception-on-unknown-os.patch
@@ -1,0 +1,15 @@
+Description: Turn #error into exceptions
+ So the library can be built on non-Linux platforms too, although can't
+ guarauntee its functionality regarding that piece of code.
+--- a/base/file.cpp
++++ b/base/file.cpp
+@@ -422,7 +422,8 @@
+   path[PATH_MAX - 1] = 0;
+   return path;
+ #else
+-#error unknown OS
++#include <stdexcept>
++  throw std::runtime_error(std::string("Unknown OS!"));
+ #endif
+ }
+ 

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/use-Python-3-for-mkbootimg.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/use-Python-3-for-mkbootimg.patch
@@ -1,0 +1,18 @@
+Description: Use Python 3 for `mkbootimg`
+Bug: https://android.googlesource.com/platform/system/core/+/c434cf82d526f07cd3dcebf53582eeddf12b0a74
+--- a/mkbootimg/mkbootimg.py
++++ b/mkbootimg/mkbootimg.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/python3
+ # Copyright 2015, The Android Open Source Project
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+--- a/mkbootimg/unpack_bootimg.py
++++ b/mkbootimg/unpack_bootimg.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/python3
+ # Copyright 2018, The Android Open Source Project
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/workaround-error-expected-primary-expression-before-.-token.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core-debian/workaround-error-expected-primary-expression-before-.-token.patch
@@ -1,0 +1,31 @@
+Description: code uses C99/C++20 constructs that g++ does not support
+ $ g++ liblog/fake_writer.cpp -o liblog/fake_writer.o  -c -std=c++17 -fPIC -Iliblog/include -Iinclude -DLIBLOG_LOG_TAG=1006 -DFAKE_LOG_DEVICE=1 -DSNET_EVENT_LOG_TAG=1397638484
+liblog/fake_writer.cpp:36:5: error: expected primary-expression before ‘.’ token
+     .context.priv = &logFds,
+     ^
+ This is an ugly hack.  The actual fix is probably to compile using
+ clang. Otherwise, these .context.priv elements shuld be initialized
+ in a different way.
+ 
+Forwarded: not-needed
+
+--- a/liblog/fake_writer.cpp
++++ b/liblog/fake_writer.cpp
+@@ -33,7 +33,6 @@
+ 
+ struct android_log_transport_write fakeLoggerWrite = {
+     .node = {&fakeLoggerWrite.node, &fakeLoggerWrite.node},
+-    .context.priv = &logFds,
+     .name = "fake",
+     .available = NULL,
+     .open = fakeOpen,
+--- a/liblog/stderr_write.cpp
++++ b/liblog/stderr_write.cpp
+@@ -56,7 +56,6 @@
+ 
+ struct android_log_transport_write stderrLoggerWrite = {
+     .node = {&stderrLoggerWrite.node, &stderrLoggerWrite.node},
+-    .context.priv = NULL,
+     .name = "stderr",
+     .available = stderrAvailable,
+     .open = stderrOpen,

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0001-patching-adb.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0001-patching-adb.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,62 @@
+From d133fc2c71fb6b0358af453b03bcb6d1874e902a Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 12:25:40 +0100
+Subject: [PATCH 01/15] patching adb.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/adb.mk | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/debian/adb.mk b/debian/adb.mk
+index 8dbacf9a..97c9d6ca 100644
+--- a/debian/adb.mk
++++ b/debian/adb.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = adb
+ 
+ SOURCES = client/adb_client.cpp \
+@@ -12,10 +13,10 @@ SOURCES = client/adb_client.cpp \
+ 
+ SOURCES := $(foreach source, $(SOURCES), adb/$(source))
+ CXXFLAGS += -std=gnu++2a
+-CPPFLAGS += -Iinclude -Iadb -Ibase/include \
++CPPFLAGS += -Iinclude -Iadb -Ibase/include  -I$(OUT_DIR)/usr/include/ \
+             -DADB_VERSION='"$(DEB_VERSION)"' -DADB_HOST=1 -D_GNU_SOURCE
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -Wl,-rpath-link=. \
+-           -lpthread -L. -ladb -lbase
++LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
++           -lpthread -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -ladb -lbase
+ 
+ # -latomic should be the last library specified
+ # https://github.com/android/ndk/issues/589
+@@ -24,7 +25,8 @@ ifneq ($(filter armel mipsel,$(DEB_HOST_ARCH)),)
+ endif
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o adb/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) adb/$(NAME)
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb/$(NAME)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0002-libadb.mk-modifications-to-make-it-build-in-yocto-en.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0002-libadb.mk-modifications-to-make-it-build-in-yocto-en.patch
@@ -1,0 +1,56 @@
+From f802e7685cfbdd66d74da2975b3a1c6d77f1a2de Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 12:28:10 +0100
+Subject: [PATCH 02/15] libadb.mk: modifications to make it build in yocto
+ environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ debian/libadb.mk | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/debian/libadb.mk b/debian/libadb.mk
+index ae240c98..db5da353 100644
+--- a/debian/libadb.mk
++++ b/debian/libadb.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME := libadb
+ 
+ LIBADB_SRC_FILES := \
+@@ -43,18 +44,18 @@ CPPFLAGS += \
+             -Ibase/include \
+             -Idiagnose_usb/include \
+             -Ilibcrypto_utils/include \
+-            -Iinclude \
++            -Iinclude -I$(OUT_DIR)/usr/include \
+             -DPLATFORM_TOOLS_VERSION='"$(PLATFORM_TOOLS_VERSION)"' \
+             -DADB_HOST=1 -DADB_VERSION='"$(DEB_VERSION)"'
+ 
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android -lcrypto \
+-           -lpthread -L. -lbase -lcutils -lcrypto_utils -lusb-1.0
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lcrypto \
++           -lpthread -lbase -lcutils -lcrypto_utils -lusb-1.0
+ 
+ $(NAME).so: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
+ 
+ transport_mdns_unsupported.cpp:
+ 	echo 'void init_mdns_transport_discovery(void) {}' > transport_mdns_unsupported.cpp
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0003-socket.h-removing-dependency-of-gtest.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0003-socket.h-removing-dependency-of-gtest.patch
@@ -1,0 +1,61 @@
+From 4fdd086c2e9c85bc5a367a861696191e190cebc9 Mon Sep 17 00:00:00 2001
+From: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+Date: Thu, 2 Mar 2023 17:20:48 +0100
+Subject: [PATCH 03/15] socket.h: removing dependency of gtest
+
+Removed the dependency of gtest on the build of fastboot binary.
+Fixes below error
+
+In file included from fastboot/fastboot.cpp:70:
+| In file included from fastboot/tcp.h:36:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/socket.cpp:29:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/tcp.cpp:29:
+| In file included from fastboot/tcp.h:36:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/udp.cpp:31:
+| In file included from fastboot/udp.h:34:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ fastboot/socket.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/fastboot/socket.h b/fastboot/socket.h
+index e791f2c8..671fc115 100644
+--- a/fastboot/socket.h
++++ b/fastboot/socket.h
+@@ -40,7 +40,6 @@
+ 
+ #include <android-base/macros.h>
+ #include <cutils/sockets.h>
+-#include <gtest/gtest_prod.h>
+ 
+ // Socket interface to be implemented for each platform.
+ class Socket {
+@@ -119,8 +118,6 @@ class Socket {
+             socket_send_buffers_function_ = &socket_send_buffers;
+ 
+   private:
+-    FRIEND_TEST(SocketTest, TestTcpSendBuffers);
+-    FRIEND_TEST(SocketTest, TestUdpSendBuffers);
+ 
+     DISALLOW_COPY_AND_ASSIGN(Socket);
+ };
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0004-patching-fastboot.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0004-patching-fastboot.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,63 @@
+From e826f68c68e05b0f5cc3b3c10d7d9e4deb135114 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:14:15 +0100
+Subject: [PATCH 04/15] patching fastboot.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/fastboot.mk | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/debian/fastboot.mk b/debian/fastboot.mk
+index d1aba626..e75fa87c 100644
+--- a/debian/fastboot.mk
++++ b/debian/fastboot.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = fastboot
+ fastboot_SOURCES = \
+           bootimg_utils.cpp \
+@@ -38,11 +39,11 @@ CPPFLAGS += \
+             -Ifs_mgr/liblp/include \
+             -I/usr/include/android/openssl \
+             -Ilibsparse/include \
+-            -Ilibziparchive/include
++            -Ilibziparchive/include -I$(OUT_DIR)/usr/include/
+ LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -fuse-ld=gold \
+-           -Wl,-rpath-link=. \
+-           -L. -lziparchive -lsparse -lbase -lcutils -ladb -lcrypto -lext4_utils \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lziparchive -lsparse -lbase -lcutils -ladb -lcrypto -lext4_utils \
+            -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -l7z \
+ 
+@@ -53,7 +54,8 @@ ifneq ($(filter armel mipsel,$(DEB_HOST_ARCH)),)
+ endif
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o fastboot/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/bin/
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) fastboot/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/$(NAME)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0005-fastboot-don-t-use-sparse_file_import_auto-in-load_b.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0005-fastboot-don-t-use-sparse_file_import_auto-in-load_b.patch
@@ -1,0 +1,54 @@
+From a4839f29e1286b0c53208a45b9c237d81021f829 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:15:47 +0100
+Subject: [PATCH 05/15] fastboot: don't use sparse_file_import_auto() in
+ load_buf_fd()
+
+upstream commit taken as below Original Issue link https://android-review.googlesource.com/c/platform/system/core/+/1123485
+
+Commit taken below:
+
+fastboot: don't use sparse_file_import_auto() in load_buf_fd()
+
+load_buf_fd() attempts to find the size of the file that it is about
+to load by first calling sparse_file_import_auto() then using
+sparse_file_len() upon success or falling back to the file size on the
+filesystem on failure.
+
+This is problematic however as sparse_file_import_auto() creates a
+sparse_file out of the normal file, but does not resparse it, so an
+assertion fails during the sparse_file_len() call.
+
+This is fixed by using sparse_file_import() instead.  This will fail
+in the case that the file is not sparse and the call to
+sparse_file_len() will be properly skipped.
+
+Bug: 140538105
+Test: flash blueline factory image with assertions enabled in
+      libsparse/sparse.cpp
+
+Change-Id: I0283be33563a3301ce5b09bde41105a20f91086c
+
+https://android.googlesource.com/platform/system/core/+/fbb9535aaea5ae4011f3c3edf4c00b27452f57ec
+Upstream-Status: Backport [commit fbb9535aaea5ae4011f3c3edf4c00b27452f57ec]
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ fastboot/fastboot.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fastboot/fastboot.cpp b/fastboot/fastboot.cpp
+index 3b7b5571..0ae9402e 100644
+--- a/fastboot/fastboot.cpp
++++ b/fastboot/fastboot.cpp
+@@ -869,7 +869,7 @@ static bool load_buf_fd(int fd, struct fastboot_buffer* buf) {
+         return false;
+     }
+ 
+-    if (sparse_file* s = sparse_file_import_auto(fd, false, false)) {
++    if (sparse_file* s = sparse_file_import(fd, false, false)) {
+         buf->image_size = sparse_file_len(s, false, false);
+         sparse_file_destroy(s);
+     } else {
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0006-libbase.mk-modifications-to-make-it-build-in-yocto-e.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0006-libbase.mk-modifications-to-make-it-build-in-yocto-e.patch
@@ -1,0 +1,45 @@
+From 22c7140dc170ecb26bde33fed4c9249b164f8d3c Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:19:08 +0100
+Subject: [PATCH 06/15] libbase.mk: modifications to make it build in yocto
+ environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ debian/libbase.mk | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/debian/libbase.mk b/debian/libbase.mk
+index 80da48f3..e6c3e365 100644
+--- a/debian/libbase.mk
++++ b/debian/libbase.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libbase
+ SOURCES = \
+           chrono_utils.cpp \
+@@ -20,8 +21,9 @@ CPPFLAGS += -Iinclude -Ibase/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r base/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0007-libcrypto_utils.mk-modifications-to-make-it-build-in.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0007-libcrypto_utils.mk-modifications-to-make-it-build-in.patch
@@ -1,0 +1,51 @@
+From cae154ec12a864ada8372b393fceb1d682c78c60 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 14:38:05 +0100
+Subject: [PATCH 07/15] libcrypto_utils.mk: modifications to make it build in
+ yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary and header to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+---
+ debian/libcrypto_utils.mk | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/debian/libcrypto_utils.mk b/debian/libcrypto_utils.mk
+index 3afd4124..80c52f30 100644
+--- a/debian/libcrypto_utils.mk
++++ b/debian/libcrypto_utils.mk
+@@ -1,15 +1,17 @@
++include ../../rules_yocto.mk
+ NAME:= libcrypto_utils
+ SOURCES := android_pubkey.c
+ SOURCES := $(foreach source, $(SOURCES), libcrypto_utils/$(source))
+-CPPFLAGS += -Ilibcrypto_utils/include -Iinclude
++CPPFLAGS += -Ilibcrypto_utils/include -Iinclude -I$(OUT_DIR)/usr/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+ 	-Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-	-L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-	-lcrypto -Wl,-z,defs
++	-L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++	-l:libcrypto.so.0 -Wl,-z,defs
+ 
+ build: $(SOURCES)
+-	$(CC) $^ -o $(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libcrypto_utils/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0008-libcutils-modifications-to-make-it-build-in-yocto-en.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0008-libcutils-modifications-to-make-it-build-in-yocto-en.patch
@@ -1,0 +1,41 @@
+From 4af9cc9e93e5cb09583c0fedeccae3fa195dbe7b Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:26:08 +0100
+Subject: [PATCH 08/15] libcutils: modifications to make it build in yocto
+ environment
+---
+ debian/libcutils.mk | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/debian/libcutils.mk b/debian/libcutils.mk
+index 7cd18d87..bb45fb57 100644
+--- a/debian/libcutils.mk
++++ b/debian/libcutils.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libcutils
+ 
+ # copied from libcutils/Android.bp
+@@ -50,14 +51,15 @@ CPPFLAGS += \
+             -Iinclude \
+ 
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+-           -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -lpthread -L. -llog -lbase
++           -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -lpthread -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -llog -lbase 
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)	
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libcutils/include/cutils $(OUT_DIR)/usr/include/	
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0009-patching-img2simg.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0009-patching-img2simg.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,53 @@
+From bea40821d787ca31b38d5879fbf751be1dbea622 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:33:30 +0100
+Subject: [PATCH 09/15] patching img2simg.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/img2simg.mk | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/debian/img2simg.mk b/debian/img2simg.mk
+index f1036cef..94772381 100644
+--- a/debian/img2simg.mk
++++ b/debian/img2simg.mk
+@@ -1,13 +1,15 @@
++include ../../rules_yocto.mk
+ NAME = img2simg
+ SOURCES = img2simg.cpp
+ SOURCES := $(foreach source, $(SOURCES), libsparse/$(source))
+ CPPFLAGS += -Ilibsparse/include -Iinclude -std=gnu++17
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -Wl,-rpath-link=. \
+-           -L. -lsparse
++LDFLAGS += -Wl,-rpath=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -lsparse
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o libsparse/$(NAME) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/bin
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/$(NAME) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) libsparse/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/$(NAME)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0010-patching-simg2img.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0010-patching-simg2img.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,53 @@
+From 08441cf4334b911dba8c493dca3b1e2166c7d322 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:34:34 +0100
+Subject: [PATCH 10/15] patching simg2img.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/simg2img.mk | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/debian/simg2img.mk b/debian/simg2img.mk
+index 07fb56b4..d319c87e 100644
+--- a/debian/simg2img.mk
++++ b/debian/simg2img.mk
+@@ -1,13 +1,15 @@
++include ../../rules_yocto.mk
+ NAME = simg2img
+ SOURCES = simg2img.cpp sparse_crc32.cpp
+ SOURCES := $(foreach source, $(SOURCES), libsparse/$(source))
+ CPPFLAGS += -Ilibsparse/include -Iinclude -std=gnu++17
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -Wl,-rpath-link=. \
+-           -L. -lsparse
++LDFLAGS += -Wl,-rpath=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lsparse
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o libsparse/$(NAME) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/bin
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/$(NAME) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) libsparse/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/$(NAME)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0011-patching-liblog.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0011-patching-liblog.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,53 @@
+From 99e46ec157e6fb912258ac6506896196e53d790b Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:35:44 +0100
+Subject: [PATCH 11/15] patching liblog.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/liblog.mk | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/debian/liblog.mk b/debian/liblog.mk
+index eb1909b9..3b40d710 100644
+--- a/debian/liblog.mk
++++ b/debian/liblog.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = liblog
+ 
+ # copied from liblog/Android.bp
+@@ -39,11 +40,12 @@ CPPFLAGS += \
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 -lpthread
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)	
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r liblog/include/* $(OUT_DIR)/usr/include/	
+ 
+ clean:
+-	$(RM) $(COBJECTS) $(CXXOBJECTS) $(NAME).so*
++	$(RM) $(COBJECTS) $(CXXOBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0012-patching-libsparse.mk-to-build-in-yocto-environment.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0012-patching-libsparse.mk-to-build-in-yocto-environment.patch
@@ -1,0 +1,58 @@
+From 65ddf7ea7daae721b2d331164155542820ed3e33 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:36:58 +0100
+Subject: [PATCH 12/15] patching libsparse.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/libsparse.mk | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/debian/libsparse.mk b/debian/libsparse.mk
+index de280def..64caa45f 100644
+--- a/debian/libsparse.mk
++++ b/debian/libsparse.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libsparse
+ SOURCES = \
+         backed_block.cpp \
+@@ -18,16 +19,16 @@ LDFLAGS += \
+   -shared -Wl,-soname,$(NAME).so.0 \
+   -lz \
+   -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-  -L. \
++  -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+   -lbase
+ 
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so	
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0013-patching-libziparchive.mk-to-build-in-yocto-environm.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0013-patching-libziparchive.mk-to-build-in-yocto-environm.patch
@@ -1,0 +1,59 @@
+From ae2bf1925fe02ea040005df27842c77c6d02b051 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:39:24 +0100
+Subject: [PATCH 13/15] patching libziparchive.mk to build in yocto
+ environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/libziparchive.mk | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/debian/libziparchive.mk b/debian/libziparchive.mk
+index 803ea58e..6a697059 100644
+--- a/debian/libziparchive.mk
++++ b/debian/libziparchive.mk
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libziparchive
+ SOURCES = zip_archive.cc \
+           zip_archive_stream_entry.cc\
+@@ -5,14 +6,15 @@ SOURCES = zip_archive.cc \
+ SOURCES := $(foreach source, $(SOURCES), libziparchive/$(source))
+ CXXFLAGS += -std=gnu++17
+ CPPFLAGS += -DZLIB_CONST -D_FILE_OFFSET_BITS=64 \
+-            -Iinclude -Ibase/include -Ilibziparchive/include
++            -Iinclude -Ibase/include -Ilibziparchive/include -I$(OUT_DIR)/usr/include/
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -lz -L. -llog -lbase
++           -lz -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -llog -lbase 
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)	
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libziparchive/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0014-patching-libbacktrace.mk-to-build-in-yocto-environme.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0014-patching-libbacktrace.mk-to-build-in-yocto-environme.patch
@@ -1,0 +1,69 @@
+From a99b74f25c7f786e26b5400218090d86596d4541 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:40:32 +0100
+Subject: [PATCH 14/15] patching libbacktrace.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+---
+ debian/libbacktrace.mk | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/debian/libbacktrace.mk b/debian/libbacktrace.mk
+index 330d211c..229b39d9 100644
+--- a/debian/libbacktrace.mk
++++ b/debian/libbacktrace.mk
+@@ -1,5 +1,5 @@
+ 
+-include /usr/share/dpkg/architecture.mk
++include ../../rules_yocto.mk
+ 
+ NAME = libbacktrace
+ 
+@@ -88,11 +88,11 @@ CPPFLAGS += \
+             -Ilibprocinfo/include \
+             -Ilibunwindstack/include \
+             -I/usr/include/android/lzma \
+-            -I/usr/include/android/unwind
++            -I$(OUT_DIR)/usr/include/android/libunwind
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android -lunwind \
+-           -L. -lbase -llog -lpthread -l7z
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lunwind \
++           -lbase -llog -lpthread -l7z
+ 
+ # -latomic should be the last library specified
+ # https://github.com/android/ndk/issues/589
+@@ -104,11 +104,11 @@ ifeq ($(DEB_HOST_ARCH), mipsel)
+ endif
+ 
+ build: $(COBJECTS) $(CXXOBJECTS) $(OBJECTS_ASSEMBLY)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -sf $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(NAME).so
+ 
+ clean:
+-	$(RM) $(COBJECTS) $(CXXOBJECTS) $(NAME).so*
++	$(RM) $(COBJECTS) $(CXXOBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(CXXOBJECTS): %.o: %.cpp
+ 	$(CXX) $< -o $@ $(CXXFLAGS) $(CPPFLAGS)
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0015-Use-namespace-std-to-compile-libbacktrace.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0015-Use-namespace-std-to-compile-libbacktrace.patch
@@ -1,0 +1,32 @@
+From 19a16829ef7b7ffd6466b9b90585d667a1663969 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Fri, 3 Mar 2023 13:43:50 +0100
+Subject: [PATCH 15/15] Use namespace std to compile libbacktrace
+
+To Fix the below error
+
+ In file included from libunwindstack/DwarfSection.cpp:21:
+| libunwindstack/include/unwindstack/DwarfMemory.h:32:29: error: unknown type name 'size_t'; did you mean 'std::size_t'?
+|   bool ReadBytes(void* dst, size_t num_bytes);
+|                             ^~~~~~
+|                             std::size_t
+---
+ libunwindstack/include/unwindstack/DwarfMemory.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libunwindstack/include/unwindstack/DwarfMemory.h b/libunwindstack/include/unwindstack/DwarfMemory.h
+index 244c0e12..0a3fefeb 100644
+--- a/libunwindstack/include/unwindstack/DwarfMemory.h
++++ b/libunwindstack/include/unwindstack/DwarfMemory.h
+@@ -23,7 +23,7 @@ namespace unwindstack {
+ 
+ // Forward declarations.
+ class Memory;
+-
++using namespace std;
+ class DwarfMemory {
+  public:
+   DwarfMemory(Memory* memory) : memory_(memory) {}
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0016-Adapt-adbd-to-work-with-yocto.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0016-Adapt-adbd-to-work-with-yocto.patch
@@ -1,0 +1,170 @@
+From fbbcb1a9359b5bf0c09bcf56b149594473f91e3a Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Wed, 8 Mar 2023 15:21:49 +0100
+Subject: [PATCH] Adapt adbd to work with yocto
+
+- remove TMPDIR which is used by commands like mktemp (set to /data/local/tmp in android
+  but vanilla linux uses /tmp per default)
+- define PS1 which was missing
+- remove android header-files and make adbd compile with yocto
+
+Co-authored-by: JJ Robertson <jrobertson@snap.com>
+Co-authored-by: Wejdene Smida <wsmida@snap.com>
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+
+---
+ adb/daemon/file_sync_service.cpp               | 4 ++--
+ adb/daemon/main.cpp                            | 4 ++--
+ adb/daemon/reboot_service.cpp                  | 5 ++++-
+ adb/daemon/set_verity_enable_state_service.cpp | 6 +++++-
+ adb/daemon/shell_service.cpp                   | 5 ++++-
+ adb/types.h                                    | 1 +
+ 6 files changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/adb/daemon/file_sync_service.cpp b/adb/daemon/file_sync_service.cpp
+index e82a51f2..ba112cbe 100644
+--- a/adb/daemon/file_sync_service.cpp
++++ b/adb/daemon/file_sync_service.cpp
+@@ -111,7 +111,7 @@ static bool secure_mkdirs(const std::string& path) {
+         partial_path += path_component;
+ 
+         if (should_use_fs_config(partial_path)) {
+-            fs_config(partial_path.c_str(), 1, nullptr, &uid, &gid, &mode, &capabilities);
++            // fs_config(partial_path.c_str(), 1, nullptr, &uid, &gid, &mode, &capabilities);
+         }
+         if (adb_mkdir(partial_path.c_str(), mode) == -1) {
+             if (errno != EEXIST) {
+@@ -434,7 +434,7 @@ static bool do_send(int s, const std::string& spec, std::vector<char>& buffer) {
+         uint64_t capabilities = 0;
+         if (should_use_fs_config(path)) {
+             unsigned int broken_api_hack = mode;
+-            fs_config(path.c_str(), 0, nullptr, &uid, &gid, &broken_api_hack, &capabilities);
++            // fs_config(path.c_str(), 0, nullptr, &uid, &gid, &broken_api_hack, &capabilities);
+             mode = broken_api_hack;
+         }
+ 
+diff --git a/adb/daemon/main.cpp b/adb/daemon/main.cpp
+index e5a49171..c75263c4 100644
+--- a/adb/daemon/main.cpp
++++ b/adb/daemon/main.cpp
+@@ -191,6 +191,8 @@ int adbd_main(int server_port) {
+     umask(0);
+ 
+     signal(SIGPIPE, SIG_IGN);
++    signal(SIGINT, SIG_DFL);
++    signal(SIGQUIT, SIG_DFL);
+ 
+ #if defined(__BIONIC__)
+     auto fdsan_level = android_fdsan_get_error_level();
+@@ -232,13 +234,11 @@ int adbd_main(int server_port) {
+ 
+     bool is_usb = false;
+ 
+-#if defined(__ANDROID__)
+     if (access(USB_FFS_ADB_EP0, F_OK) == 0) {
+         // Listen on USB.
+         usb_init();
+         is_usb = true;
+     }
+-#endif
+ 
+     // If one of these properties is set, also listen on that port.
+     // If one of the properties isn't set and we couldn't listen on usb, listen
+diff --git a/adb/daemon/reboot_service.cpp b/adb/daemon/reboot_service.cpp
+index a5a11b86..6bd069d4 100644
+--- a/adb/daemon/reboot_service.cpp
++++ b/adb/daemon/reboot_service.cpp
+@@ -28,7 +28,9 @@
+ #include <android-base/logging.h>
+ #include <android-base/properties.h>
+ #include <android-base/stringprintf.h>
+-#include <bootloader_message/bootloader_message.h>
++// #include <bootloader_message/bootloader_message.h>
++#include <linux/reboot.h>
++#include <sys/signal.h>
+ #include <cutils/android_reboot.h>
+ 
+ #include "adb_io.h"
+@@ -76,6 +78,7 @@ void reboot_service(unique_fd fd, const std::string& arg) {
+             return;
+         }
+     }
++    syscall(__NR_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, LINUX_REBOOT_CMD_RESTART2, reboot_arg.c_str());
+     // Don't return early. Give the reboot command time to take effect
+     // to avoid messing up scripts which do "adb reboot && adb wait-for-device"
+     while (true) {
+diff --git a/adb/daemon/set_verity_enable_state_service.cpp b/adb/daemon/set_verity_enable_state_service.cpp
+index 889229fe..51e9be93 100644
+--- a/adb/daemon/set_verity_enable_state_service.cpp
++++ b/adb/daemon/set_verity_enable_state_service.cpp
+@@ -22,7 +22,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
+-#include <libavb_user/libavb_user.h>
++// #include <libavb_user/libavb_user.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/mount.h>
+@@ -65,6 +65,7 @@ static bool make_block_device_writable(const std::string& dev) {
+ /* Turn verity on/off */
+ static bool set_verity_enabled_state(int fd, const char* block_device, const char* mount_point,
+                                      bool enable) {
++#if defined(__ANDROID__)
+     if (!make_block_device_writable(block_device)) {
+         WriteFdFmt(fd, "Could not make block device %s writable (%s).\n",
+                    block_device, strerror(errno));
+@@ -115,6 +116,7 @@ static bool set_verity_enabled_state(int fd, const char* block_device, const cha
+                    mount_point, strerror(errno));
+     }
+     WriteFdFmt(fd, "Verity %s on %s\n", enable ? "enabled" : "disabled", mount_point);
++#endif
+     return true;
+ }
+ 
+@@ -126,6 +128,7 @@ static std::string get_ab_suffix() {
+     return android::base::GetProperty("ro.boot.slot_suffix", "");
+ }
+ 
++#if defined(__ANDROID__)
+ static bool is_avb_device_locked() {
+     return android::base::GetProperty("ro.boot.vbmeta.device_state", "") == "locked";
+ }
+@@ -245,3 +248,4 @@ void set_verity_enabled_state_service(unique_fd fd, bool enable) {
+         WriteFdExactly(fd.get(), "Now reboot your device for settings to take effect\n");
+     }
+ }
++#endif
+diff --git a/adb/daemon/shell_service.cpp b/adb/daemon/shell_service.cpp
+index 3c8f3939..355c1a1c 100644
+--- a/adb/daemon/shell_service.cpp
++++ b/adb/daemon/shell_service.cpp
+@@ -261,9 +261,12 @@ bool Subprocess::ForkAndExec(std::string* error) {
+         env["HOSTNAME"] = GetHostName();
+         env["LOGNAME"] = pw->pw_name;
+         env["SHELL"] = pw->pw_shell;
+-        env["TMPDIR"] = "/data/local/tmp";
+         env["USER"] = pw->pw_name;
+     }
++    if (env.find("PS1") == env.end()) {
++        env["PS1"] = "\\h:\\w\\$ ";
++    }
++
+ 
+     if (!terminal_type_.empty()) {
+         env["TERM"] = terminal_type_;
+diff --git a/adb/types.h b/adb/types.h
+index 6af4a150..9efe223b 100644
+--- a/adb/types.h
++++ b/adb/types.h
+@@ -20,6 +20,7 @@
+ #include <cstring>
+ #include <deque>
+ #include <memory>
++#include <string>
+ #include <type_traits>
+ #include <utility>
+ #include <vector>
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0017-Update-usage-of-usbdevfs_urb-to-match-new-kernel-UAP.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0017-Update-usage-of-usbdevfs_urb-to-match-new-kernel-UAP.patch
@@ -1,0 +1,128 @@
+From 0dac14385d9c79089f8026e2764b75fa111adb8a Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Tue, 14 Mar 2023 11:33:50 +0100
+Subject: [PATCH] Update usage of usbdevfs_urb to match new kernel UAPI
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Linux kernel API has been changed by commit 94dfc73e7cf4 ("treewide: uapi: Replace zero-length arrays with flexible-array members")
+where zero-length array iso_frame_desc in struct usbdevfs_urb was replaced with a proper flexible-array member.
+
+Current USB API usage causes a compilation error at Linux 6.0:
+
+In file included from /home/mae/.cache/kiss/proc/121205/build/android-tools/vendor/adb/client/usb_linux.cpp:28:
+/usr/include/linux/usbdevice_fs.h:134:41: error: flexible array member ‘usbdevfs_urb::iso_frame_desc’ not at end of ‘struct usb_handle’
+  134 |         struct usbdevfs_iso_packet_desc iso_frame_desc[];
+      |                                         ^~~~~~~~~~~~~~
+/home/mae/.cache/kiss/proc/121205/build/android-tools/vendor/adb/client/usb_linux.cpp:76:18: note: next member ‘usbdevfs_urb usb_handle::urb_out’ declared here
+   76 |     usbdevfs_urb urb_out;
+      |                  ^~~~~~~
+/home/mae/.cache/kiss/proc/121205/build/android-tools/vendor/adb/client/usb_linux.cpp:61:8: note: in the definition of ‘struct usb_handle’
+   61 | struct usb_handle {
+      |        ^~~~~~~~~~
+
+Fix it by using pointers to a struct with flexible-array members.
+Current fix works both with the old and the new API.
+
+See https://github.com/nmeum/android-tools/issues/74 for more context.
+
+Tested: built on Linux against kernel 5.19 and 6.0; 'adb shell' over USB
+cable
+Acked-by: Gustavo A. R. Silva gustavoars@kernel.org
+Change-Id: I7f0f7b35d9a3ab980d3520b541b60c7857a6b101
+Signed-off-by: Anatol Pomozov <anatol.pomozov@gmail.com>
+
+[Backported on version 10]
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+---
+ adb/client/usb_linux.cpp | 24 ++++++++++++++----------
+ 1 file changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/adb/client/usb_linux.cpp b/adb/client/usb_linux.cpp
+index 81b83064..7d55ec5b 100644
+--- a/adb/client/usb_linux.cpp
++++ b/adb/client/usb_linux.cpp
+@@ -71,8 +71,8 @@ struct usb_handle : public ::usb_handle {
+     unsigned zero_mask;
+     unsigned writeable = 1;
+ 
+-    usbdevfs_urb urb_in;
+-    usbdevfs_urb urb_out;
++    usbdevfs_urb *urb_in;
++    usbdevfs_urb *urb_out;
+ 
+     bool urb_in_busy = false;
+     bool urb_out_busy = false;
+@@ -305,7 +305,7 @@ static int usb_bulk_write(usb_handle* h, const void* data, int len) {
+     std::unique_lock<std::mutex> lock(h->mutex);
+     D("++ usb_bulk_write ++");
+ 
+-    usbdevfs_urb* urb = &h->urb_out;
++    usbdevfs_urb* urb = h->urb_out;
+     memset(urb, 0, sizeof(*urb));
+     urb->type = USBDEVFS_URB_TYPE_BULK;
+     urb->endpoint = h->ep_out;
+@@ -344,7 +344,7 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+     std::unique_lock<std::mutex> lock(h->mutex);
+     D("++ usb_bulk_read ++");
+ 
+-    usbdevfs_urb* urb = &h->urb_in;
++    usbdevfs_urb* urb = h->urb_in;
+     memset(urb, 0, sizeof(*urb));
+     urb->type = USBDEVFS_URB_TYPE_BULK;
+     urb->endpoint = h->ep_in;
+@@ -389,7 +389,7 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+         }
+         D("[ urb @%p status = %d, actual = %d ]", out, out->status, out->actual_length);
+ 
+-        if (out == &h->urb_in) {
++        if (out == h->urb_in) {
+             D("[ reap urb - IN complete ]");
+             h->urb_in_busy = false;
+             if (urb->status != 0) {
+@@ -398,7 +398,7 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+             }
+             return urb->actual_length;
+         }
+-        if (out == &h->urb_out) {
++        if (out == h->urb_out) {
+             D("[ reap urb - OUT compelete ]");
+             h->urb_out_busy = false;
+             h->cv.notify_all();
+@@ -483,10 +483,10 @@ void usb_kick(usb_handle* h) {
+             ** but this ensures that a reader blocked on REAPURB
+             ** will get unblocked
+             */
+-            ioctl(h->fd, USBDEVFS_DISCARDURB, &h->urb_in);
+-            ioctl(h->fd, USBDEVFS_DISCARDURB, &h->urb_out);
+-            h->urb_in.status = -ENODEV;
+-            h->urb_out.status = -ENODEV;
++            ioctl(h->fd, USBDEVFS_DISCARDURB, h->urb_in);
++            ioctl(h->fd, USBDEVFS_DISCARDURB, h->urb_out);
++            h->urb_in->status = -ENODEV;
++            h->urb_out->status = -ENODEV;
+             h->urb_in_busy = false;
+             h->urb_out_busy = false;
+             h->cv.notify_all();
+@@ -502,6 +502,8 @@ int usb_close(usb_handle* h) {
+ 
+     D("-- usb close %p (fd = %d) --", h, h->fd);
+ 
++    delete h->urb_in;
++    delete h->urb_out;
+     delete h;
+ 
+     return 0;
+@@ -537,6 +539,8 @@ static void register_device(const char* dev_name, const char* dev_path, unsigned
+     usb->ep_out = ep_out;
+     usb->zero_mask = zero_mask;
+     usb->max_packet_size = max_packet_size;
++    usb->urb_in = new usbdevfs_urb;
++    usb->urb_out = new usbdevfs_urb;
+ 
+     // Initialize mark so we don't get garbage collected after the device scan.
+     usb->mark = true;
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0018-img2simg-Fix-wrong-rpath.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0018-img2simg-Fix-wrong-rpath.patch
@@ -1,0 +1,26 @@
+From 25bd3456dcd539b89648273152e405314287f4f8 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Mon, 13 Mar 2023 13:46:14 +0100
+Subject: [PATCH 2/2] img2simg: Fix wrong rpath and re-add libbase
+
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+---
+ debian/img2simg.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/img2simg.mk b/debian/img2simg.mk
+index d1b9b927..459af454 100644
+--- a/debian/img2simg.mk
++++ b/debian/img2simg.mk
+@@ -3,7 +3,7 @@ NAME = img2simg
+ SOURCES = img2simg.cpp
+ SOURCES := $(foreach source, $(SOURCES), libsparse/$(source))
+ CPPFLAGS += -Ilibsparse/include -Iinclude -std=gnu++17
+-LDFLAGS += -Wl,-rpath=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++LDFLAGS += -Wl,-rpath='$$ORIGIN/../lib/android' -lbase \
+            -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+            -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -lsparse
+ 
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0019-Fix-compilation-with-gcc.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0019-Fix-compilation-with-gcc.patch
@@ -1,0 +1,157 @@
+From d198ecb4c36b645e5428aa5117f7673bf2f7a3e6 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Tue, 14 Mar 2023 11:42:08 +0100
+Subject: [PATCH] Fix compilation with gcc
+
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+---
+ adb/adb_listeners.cpp   | 18 ++++++++++++------
+ adb/daemon/auth.cpp     |  3 ++-
+ adb/daemon/usb.cpp      |  3 ++-
+ adb/fdevent.cpp         |  3 ++-
+ adb/transport_fd.cpp    |  3 ++-
+ adb/transport_local.cpp |  3 ++-
+ 6 files changed, 22 insertions(+), 11 deletions(-)
+
+diff --git a/adb/adb_listeners.cpp b/adb/adb_listeners.cpp
+index 29909a55..fbdf4487 100644
+--- a/adb/adb_listeners.cpp
++++ b/adb/adb_listeners.cpp
+@@ -109,7 +109,8 @@ static void listener_event_func(int _fd, unsigned ev, void* _l)
+ }
+ 
+ // Called as a transport disconnect function. |arg| is the raw alistener*.
+-static void listener_disconnect(void* arg, atransport*) EXCLUDES(listener_list_mutex) {
++ EXCLUDES(listener_list_mutex)
++static void listener_disconnect(void* arg, atransport*) {
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     for (auto iter = listener_list.begin(); iter != listener_list.end(); ++iter) {
+         if (iter->get() == arg) {
+@@ -121,7 +122,8 @@ static void listener_disconnect(void* arg, atransport*) EXCLUDES(listener_list_m
+ }
+ 
+ // Write the list of current listeners (network redirections) into a string.
+-std::string format_listeners() EXCLUDES(listener_list_mutex) {
++EXCLUDES(listener_list_mutex)
++std::string format_listeners() {
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     std::string result;
+     for (auto& l : listener_list) {
+@@ -139,8 +141,9 @@ std::string format_listeners() EXCLUDES(listener_list_mutex) {
+     return result;
+ }
+ 
++EXCLUDES(listener_list_mutex)
+ InstallStatus remove_listener(const char* local_name, atransport* transport)
+-    EXCLUDES(listener_list_mutex) {
++{
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     for (auto iter = listener_list.begin(); iter != listener_list.end(); ++iter) {
+         if (local_name == (*iter)->local_name) {
+@@ -151,7 +154,8 @@ InstallStatus remove_listener(const char* local_name, atransport* transport)
+     return INSTALL_STATUS_LISTENER_NOT_FOUND;
+ }
+ 
+-void remove_all_listeners() EXCLUDES(listener_list_mutex) {
++EXCLUDES(listener_list_mutex)
++void remove_all_listeners() {
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     auto iter = listener_list.begin();
+     while (iter != listener_list.end()) {
+@@ -164,7 +168,8 @@ void remove_all_listeners() EXCLUDES(listener_list_mutex) {
+     }
+ }
+ 
+-void close_smartsockets() EXCLUDES(listener_list_mutex) {
++EXCLUDES(listener_list_mutex)
++void close_smartsockets() {
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     auto pred = [](const std::unique_ptr<alistener>& listener) {
+         return listener->local_name == "*smartsocket*";
+@@ -172,9 +177,10 @@ void close_smartsockets() EXCLUDES(listener_list_mutex) {
+     listener_list.remove_if(pred);
+ }
+ 
++EXCLUDES(listener_list_mutex)
+ InstallStatus install_listener(const std::string& local_name, const char* connect_to,
+                                atransport* transport, int no_rebind, int* resolved_tcp_port,
+-                               std::string* error) EXCLUDES(listener_list_mutex) {
++                               std::string* error) {
+     std::lock_guard<std::mutex> lock(listener_list_mutex);
+     for (auto& l : listener_list) {
+         if (local_name == l->local_name) {
+diff --git a/adb/daemon/auth.cpp b/adb/daemon/auth.cpp
+index a18afa4e..0fd60a1f 100644
+--- a/adb/daemon/auth.cpp
++++ b/adb/daemon/auth.cpp
+@@ -98,8 +98,9 @@ bool adbd_auth_verify(const char* token, size_t token_size, const std::string& s
+     return false;
+ }
+ 
++REQUIRES(framework_mutex)
+ static bool adbd_send_key_message_locked(std::string_view msg_type, std::string_view key)
+-        REQUIRES(framework_mutex) {
++{
+     if (framework_fd < 0) {
+         LOG(ERROR) << "Client not connected to send msg_type " << msg_type;
+         return false;
+diff --git a/adb/daemon/usb.cpp b/adb/daemon/usb.cpp
+index 1abae87c..3a466782 100644
+--- a/adb/daemon/usb.cpp
++++ b/adb/daemon/usb.cpp
+@@ -628,7 +628,8 @@ struct UsbFfsConnection : public Connection {
+         return CreateWriteBlock(std::move(block), 0, len, id);
+     }
+ 
+-    void SubmitWrites() REQUIRES(write_mutex_) {
++    REQUIRES(write_mutex_)
++    void SubmitWrites() {
+         if (writes_submitted_ == kUsbWriteQueueDepth) {
+             return;
+         }
+diff --git a/adb/fdevent.cpp b/adb/fdevent.cpp
+index 32f90863..bff24544 100644
+--- a/adb/fdevent.cpp
++++ b/adb/fdevent.cpp
+@@ -376,7 +376,8 @@ static void fdevent_call_fdfunc(fdevent* fde) {
+             fde->func);
+ }
+ 
+-static void fdevent_run_flush() EXCLUDES(run_queue_mutex) {
++EXCLUDES(run_queue_mutex)
++static void fdevent_run_flush() {
+     // We need to be careful around reentrancy here, since a function we call can queue up another
+     // function.
+     while (true) {
+diff --git a/adb/transport_fd.cpp b/adb/transport_fd.cpp
+index a93e68a0..c5af09ff 100644
+--- a/adb/transport_fd.cpp
++++ b/adb/transport_fd.cpp
+@@ -168,7 +168,8 @@ struct NonblockingFdConnection : public Connection {
+         TryAgain,
+     };
+ 
+-    WriteResult DispatchWrites() REQUIRES(write_mutex_) {
++    REQUIRES(write_mutex_)
++    WriteResult DispatchWrites() {
+         CHECK(!write_buffer_.empty());
+         auto iovs = write_buffer_.iovecs();
+         ssize_t rc = adb_writev(fd_.get(), iovs.data(), iovs.size());
+diff --git a/adb/transport_local.cpp b/adb/transport_local.cpp
+index b9f738df..a273e8f7 100644
+--- a/adb/transport_local.cpp
++++ b/adb/transport_local.cpp
+@@ -345,8 +345,9 @@ struct EmulatorConnection : public FdConnection {
+ };
+ 
+ /* Only call this function if you already hold local_transports_lock. */
++REQUIRES(local_transports_lock)
+ static atransport* find_emulator_transport_by_adb_port_locked(int adb_port)
+-    REQUIRES(local_transports_lock) {
++{
+     auto it = local_transports.find(adb_port);
+     if (it == local_transports.end()) {
+         return nullptr;
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0020-adb-Fix-build-on-big-endian-systems.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0020-adb-Fix-build-on-big-endian-systems.patch
@@ -1,0 +1,50 @@
+From f9fe8163cd759c21dd5ec0711b56dccd79ff1c4a Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Tue, 14 Mar 2023 13:39:23 +0100
+Subject: [PATCH] adb: Fix build on big endian systems
+
+The usb_linux_client.c file defines cpu_to_le16/32 by using the C
+library htole16/32 function calls. However, cpu_to_le16/32 are used
+when initializing structures, i.e in a context where a function call
+is not allowed.
+
+It works fine on little endian systems because htole16/32 are defined
+by the C library as no-ops. But on big-endian systems, they are
+actually doing something, which might involve calling a function,
+causing build failures.
+
+To solve this, we simply open-code cpu_to_le16/32 in a way that allows
+them to be used when initializing structures.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+[Forward-ported to version 10]
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+---
+ adb/daemon/usb_ffs.cpp | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/adb/daemon/usb_ffs.cpp b/adb/daemon/usb_ffs.cpp
+index 07b4ba89..25f30352 100644
+--- a/adb/daemon/usb_ffs.cpp
++++ b/adb/daemon/usb_ffs.cpp
+@@ -37,8 +37,15 @@
+ // Number of buffers needed to fit MAX_PAYLOAD, with an extra for ZLPs.
+ #define USB_FFS_NUM_BUFS ((4 * MAX_PAYLOAD / USB_FFS_BULK_SIZE) + 1)
+ 
+-#define cpu_to_le16(x) htole16(x)
+-#define cpu_to_le32(x) htole32(x)
++#if __BYTE_ORDER == __LITTLE_ENDIAN
++# define cpu_to_le16(x) (x)
++# define cpu_to_le32(x) (x)
++#else
++# define cpu_to_le16(x) ((((x) >> 8) & 0xffu) | (((x) & 0xffu) << 8))
++# define cpu_to_le32(x) \
++	((((x) & 0xff000000u) >> 24) | (((x) & 0x00ff0000u) >>  8) | \
++	 (((x) & 0x0000ff00u) <<  8) | (((x) & 0x000000ffu) << 24))
++#endif
+ 
+ struct func_desc {
+     struct usb_interface_descriptor intf;
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0021-adb-Allow-adbd-to-be-run-as-root.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/core/0021-adb-Allow-adbd-to-be-run-as-root.patch
@@ -1,0 +1,25 @@
+From 0bc94c83b9d846416613f9c8831cae6caf1713e5 Mon Sep 17 00:00:00 2001
+From: Etienne Cordonnier <ecordonnier@snap.com>
+Date: Tue, 14 Mar 2023 13:53:51 +0100
+Subject: [PATCH] adb: Allow adbd to be run as root
+
+Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>
+---
+ adb/daemon/main.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/adb/daemon/main.cpp b/adb/daemon/main.cpp
+index c75263c4..d27f6996 100644
+--- a/adb/daemon/main.cpp
++++ b/adb/daemon/main.cpp
+@@ -72,6 +72,7 @@ static bool should_drop_capabilities_bounding_set() {
+ }
+ 
+ static bool should_drop_privileges() {
++    return true;
+     // "adb root" not allowed, always drop privileges.
+     if (!ALLOW_ADBD_ROOT && !is_device_unlocked()) return true;
+ 
+-- 
+2.36.1.vfs.0.0
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libcrypto_utils_mk_change_out_dir.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libcrypto_utils_mk_change_out_dir.patch
@@ -1,0 +1,39 @@
+libcrypto_utils.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary and header to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/debian/libcrypto_utils.mk	2021-04-30 14:18:54.071379767 +0200
++++ git/debian/libcrypto_utils.mk	2021-04-30 14:22:46.179047308 +0200
+@@ -1,15 +1,17 @@
++include ../../rules_yocto.mk
+ NAME:= libcrypto_utils
+ SOURCES := android_pubkey.c
+ SOURCES := $(foreach source, $(SOURCES), libcrypto_utils/$(source))
+-CPPFLAGS += -Ilibcrypto_utils/include -Iinclude
++CPPFLAGS += -Ilibcrypto_utils/include -Iinclude -I$(OUT_DIR)/usr/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+ 	-Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-	-L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-	-lcrypto -Wl,-z,defs
++	-L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++	-l:libcrypto.so.0 -Wl,-z,defs
+ 
+ build: $(SOURCES)
+-	$(CC) $^ -o $(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
++	ln -sf $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libcrypto_utils/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/20150704-CVE-2015-3239_dwarf_i.h.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/20150704-CVE-2015-3239_dwarf_i.h.patch
@@ -1,0 +1,14 @@
+Description: Fixes "20150704-CVE-2015-3239"
+Index: pkg-libunwind/include/dwarf_i.h
+===================================================================
+--- pkg-libunwind.orig/include/dwarf_i.h	2015-07-04 10:57:29.000000000 +0900
++++ pkg-libunwind/include/dwarf_i.h	2015-07-04 11:06:08.675616821 +0900
+@@ -20,7 +20,7 @@
+ extern const uint8_t dwarf_to_unw_regnum_map[DWARF_REGNUM_MAP_LENGTH];
+ /* REG is evaluated multiple times; it better be side-effects free!  */
+ # define dwarf_to_unw_regnum(reg)					  \
+-  (((reg) <= DWARF_REGNUM_MAP_LENGTH) ? dwarf_to_unw_regnum_map[reg] : 0)
++  (((reg) < DWARF_REGNUM_MAP_LENGTH) ? dwarf_to_unw_regnum_map[reg] : 0)
+ #endif
+ 
+ #ifdef UNW_LOCAL_ONLY

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/legacy_built-in_sync_functions.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/legacy_built-in_sync_functions.patch
@@ -1,0 +1,25 @@
+Description: Replace the legacy __sync built-in functions with __atomic ones
+ libunwind uses the built-in __sync_* functions which are deprecated by GCC and
+ should be replaced by __atomic_* ones. See the official manuals [1].
+ .
+ The legacy __sync functions do not require to specify the memory order but
+ __atomic ones do, so we choose the strongest one: __ATOMIC_SEQ_CST.
+ .
+ We do this because __sync_fetch_and_add() is not supported on armel.
+ .
+ [1]: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html
+Author: Kai-Chung Yan ()
+Last-Update: 2016-10-04
+--- a/include/libunwind_i.h
++++ b/include/libunwind_i.h
+@@ -155,8 +155,8 @@
+   u.vp = addr;
+   return __sync_bool_compare_and_swap(u.vlp, (long) old, (long) new);
+ }
+-# define fetch_and_add1(_ptr)		__sync_fetch_and_add(_ptr, 1)
+-# define fetch_and_add(_ptr, value)	__sync_fetch_and_add(_ptr, value)
++# define fetch_and_add1(_ptr) __atomic_fetch_add(_ptr, 1, __ATOMIC_SEQ_CST)
++# define fetch_and_add(_ptr, value) __atomic_fetch_add(_ptr, value, __ATOMIC_SEQ_CST)
+ # define HAVE_CMPXCHG
+ # define HAVE_FETCH_AND_ADD
+ #endif

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/series
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/series
@@ -1,0 +1,3 @@
+user_pt_regs.patch
+legacy_built-in_sync_functions.patch
+20150704-CVE-2015-3239_dwarf_i.h.patch

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/user_pt_regs.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/libunwind-debian/user_pt_regs.patch
@@ -1,0 +1,23 @@
+Author: Kai-Chung Yan <seamlikok@gmail.com>
+Last-Update: 2016-08-24
+Description: Manual definition of struct user_pt_regs
+ On ARM64, libunwind uses struct user_pt_regs which is not defined in
+ anywhere, which causes FTBFS.
+--- a/src/ptrace/_UPT_access_reg.c
++++ b/src/ptrace/_UPT_access_reg.c
+@@ -26,6 +26,15 @@
+ 
+ #include "_UPT_internal.h"
+ 
++#if defined(__aarch64__)
++  struct user_pt_regs {
++    __u64		regs[31];
++    __u64		sp;
++    __u64		pc;
++    __u64		pstate;
++  };
++#endif
++
+ #if UNW_TARGET_IA64
+ # include <elf.h>
+ # ifdef HAVE_ASM_PTRACE_OFFSETS_H

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/rules_yocto.mk
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/rules_yocto.mk
@@ -1,0 +1,4 @@
+CPPFLAGS += -fPIC
+ifndef OUT_DIR
+OUT_DIR = ../../debian/out
+endif

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools_10.0.0.r36.bb
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools_10.0.0.r36.bb
@@ -1,0 +1,227 @@
+DESCRIPTION = "Different utilities from Android"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0 & GPL-2.0-only & BSD-2-Clause & BSD-3-Clause"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+    file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6 \
+    file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f \
+    file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
+"
+DEPENDS = "libbsd libpcre zlib libcap libusb squashfs-tools p7zip libselinux"
+
+ANDROID_MIRROR = "android.googlesource.com"
+
+# matches with 10.0.0+r36
+SRCREV_boringssl = "ae2dd49c7cb74d04bdba7c1c9bd62c1e9cdf98f6"
+SRCREV_core = "5aa13b053182b758d7a19db0c83e1b9b5bf1ec2e"
+SRCREV_extras = "d31740f9d0399f8b938e88e58843d966e1cccab6"
+SRCREV_libhardware = "c6925520342a7d37758f85eb1cf3baa20a7b7a18"
+SRCREV_build = "28768b3120f751583a2743101b892f210d4715cf"
+SRCREV_libunwind = "03a963ecf6ea836b38b3537cbcda0ecfd7a77393"
+
+SRC_URI = " \
+    git://salsa.debian.org/android-tools-team/android-platform-external-boringssl;name=boringssl;protocol=https;nobranch=1;destsuffix=git/external/boringssl \
+    git://salsa.debian.org/android-tools-team/android-platform-system-core;name=core;protocol=https;nobranch=1;destsuffix=git/system/core \
+    git://salsa.debian.org/android-tools-team/android-platform-system-extras;name=extras;protocol=https;nobranch=1;destsuffix=git/system/extras \
+    git://${ANDROID_MIRROR}/platform/hardware/libhardware;name=libhardware;protocol=https;nobranch=1;destsuffix=git/hardware/libhardware \
+    git://salsa.debian.org/android-tools-team/android-platform-build.git;name=build;protocol=https;nobranch=1;destsuffix=git/build \
+    git://salsa.debian.org/android-tools-team/android-platform-external-libunwind.git;protocol=https;name=libunwind;nobranch=1;destsuffix=git/external/libunwind \
+"
+
+# Patches copied from android-platform-system-core/debian/patches
+# and applied in the order defined by the "series" file
+SRC_URI += " \
+    file://core-debian/move-log-file-to-proper-dir.patch;patchdir=system/core \
+    file://core-debian/Added-missing-headers.patch;patchdir=system/core \
+    file://core-debian/libusb-header-path.patch;patchdir=system/core \
+    file://core-debian/stdatomic.patch;patchdir=system/core \
+    file://core-debian/Nonnull.patch;patchdir=system/core \
+    file://core-debian/Vector-cast.patch;patchdir=system/core \
+    file://core-debian/use-Python-3-for-mkbootimg.patch;patchdir=system/core \
+    file://core-debian/throw-exception-on-unknown-os.patch;patchdir=system/core \
+    file://core-debian/simg_dump-python3.patch;patchdir=system/core \
+    file://core-debian/fix-attribute-issue-with-gcc.patch;patchdir=system/core \
+    file://core-debian/workaround-error-expected-primary-expression-before-.-token.patch;patchdir=system/core \
+    file://core-debian/fix-gettid-exception-declaration.patch;patchdir=system/core \
+    file://core-debian/fix-build-on-non-x86.patch;patchdir=system/core \
+    file://core-debian/add-missing-headers.patch;patchdir=system/core \
+    file://core-debian/hard-code-build-number.patch;patchdir=system/core \
+    file://core-debian/fix-gcc-11-ftbfs.patch;patchdir=system/core \
+    file://core-debian/fix-gnu-hurd.patch;patchdir=system/core \
+"
+
+# Patches copied from android-platform-external-libunwind/debian/patches
+# and applied in the order defined by the "series" file
+SRC_URI += " \
+    file://libunwind-debian/user_pt_regs.patch;patchdir=external/libunwind \
+    file://libunwind-debian/legacy_built-in_sync_functions.patch;patchdir=external/libunwind \
+    file://libunwind-debian/20150704-CVE-2015-3239_dwarf_i.h.patch;patchdir=external/libunwind \
+"
+
+# meta-openembedded specific patches + files:
+SRC_URI += " \
+    file://core/0001-patching-adb.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0002-libadb.mk-modifications-to-make-it-build-in-yocto-en.patch;patchdir=system/core \
+    file://core/0003-socket.h-removing-dependency-of-gtest.patch;patchdir=system/core \
+    file://core/0004-patching-fastboot.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0005-fastboot-don-t-use-sparse_file_import_auto-in-load_b.patch;patchdir=system/core \
+    file://core/0006-libbase.mk-modifications-to-make-it-build-in-yocto-e.patch;patchdir=system/core \
+    file://core/0007-libcrypto_utils.mk-modifications-to-make-it-build-in.patch;patchdir=system/core \
+    file://core/0008-libcutils-modifications-to-make-it-build-in-yocto-en.patch;patchdir=system/core \
+    file://core/0009-patching-img2simg.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0010-patching-simg2img.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0011-patching-liblog.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0012-patching-libsparse.mk-to-build-in-yocto-environment.patch;patchdir=system/core \
+    file://core/0013-patching-libziparchive.mk-to-build-in-yocto-environm.patch;patchdir=system/core \
+    file://core/0014-patching-libbacktrace.mk-to-build-in-yocto-environme.patch;patchdir=system/core \
+    file://core/0015-Use-namespace-std-to-compile-libbacktrace.patch;patchdir=system/core \
+    file://core/0016-Adapt-adbd-to-work-with-yocto.patch;patchdir=system/core \
+    file://core/0017-Update-usage-of-usbdevfs_urb-to-match-new-kernel-UAP.patch;patchdir=system/core \
+    file://core/0018-img2simg-Fix-wrong-rpath.patch;patchdir=system/core \
+    file://core/0019-Fix-compilation-with-gcc.patch;patchdir=system/core \
+    file://core/0020-adb-Fix-build-on-big-endian-systems.patch;patchdir=system/core \
+    file://core/0021-adb-Allow-adbd-to-be-run-as-root.patch;patchdir=system/core \
+    file://0001-libcrypto.mk-modifications-to-make-it-build-in-yocto.patch;patchdir=external/boringssl \
+    file://0001-patching-libundwind-to-build-in-yocto-environment.patch;patchdir=external/libunwind \
+    file://0001-libext4_utils.mk-modifications-to-make-it-build-in-y.patch;patchdir=system/extras \
+    file://0002-libfec-change-out_dir-in-makefile.patch;patchdir=system/extras \
+    file://rules_yocto.mk;subdir=git \
+    file://android-tools-adbd.service \
+    file://adbd.mk;subdir=git/system/core/debian \
+"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/${BPN}"
+
+# http://errors.yoctoproject.org/Errors/Details/1debian881/
+ARM_INSTRUCTION_SET:armv4 = "arm"
+ARM_INSTRUCTION_SET:armv5 = "arm"
+
+COMPATIBLE_HOST:powerpc = "(null)"
+COMPATIBLE_HOST:powerpc64 = "(null)"
+COMPATIBLE_HOST:powerpc64le = "(null)"
+
+# Find libbsd headers during native builds
+CC:append:class-native = " -I${STAGING_INCDIR}"
+CC:append:class-nativesdk = " -I${STAGING_INCDIR}"
+
+PREREQUISITE_core = "libbase libsparse liblog libcutils"
+TOOLS_TO_BUILD = "libcrypto_utils libadb libziparchive fastboot adb img2simg simg2img libbacktrace"
+TOOLS_TO_BUILD:append:class-target = " adbd"
+
+do_compile() {
+
+    case "${HOST_ARCH}" in
+      arm)
+        export android_arch=linux-arm
+        cpu=arm
+        deb_host_arch=arm
+      ;;
+      aarch64)
+        export android_arch=linux-arm64
+        cpu=arm64
+        deb_host_arch=arm64
+      ;;
+      riscv64)
+        export android_arch=linux-riscv64
+      ;;
+      mips|mipsel)
+        export android_arch=linux-mips
+        cpu=mips
+        deb_host_arch=mips
+      ;;
+      mips64|mips64el)
+        export android_arch=linux-mips64
+        cpu=mips64
+        deb_host_arch=mips64
+      ;;
+      powerpc|powerpc64)
+        export android_arch=linux-ppc
+      ;;
+      i586|i686|x86_64)
+        export android_arch=linux-x86
+        cpu=x86_64
+        deb_host_arch=amd64
+      ;;
+    esac
+
+    export SRCDIR=${S}
+
+    oe_runmake -f ${S}/external/boringssl/debian/libcrypto.mk -C ${S}/external/boringssl
+    oe_runmake -f ${S}/external/libunwind/debian/libunwind.mk -C ${S}/external/libunwind CPU=${cpu}
+
+    for tool in ${PREREQUISITE_core}; do
+      oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core
+    done
+
+    for i in `find ${S}/system/extras/debian/ -name "*.mk"`; do
+        oe_runmake -f $i -C ${S}/system/extras
+    done
+
+    for tool in ${TOOLS_TO_BUILD}; do
+        if [ "$tool" = "libbacktrace" ]; then
+            oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core DEB_HOST_ARCH=${deb_host_arch}
+        else
+            oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core
+        fi
+    done
+
+}
+
+do_install() {
+    for tool in img2simg simg2img fastboot; do
+        if echo ${TOOLS_TO_BUILD} | grep -q "$tool" ; then
+            install -D -p -m0755 ${S}/debian/out/usr/bin/$tool ${D}${bindir}/$tool
+        fi
+    done
+
+    if echo ${TOOLS_TO_BUILD} | grep -q "adb " ; then
+        install -d ${D}${bindir}
+        install -m0755 ${S}/debian/out/usr/lib/android/adb/adb ${D}${bindir}
+    fi
+
+    if echo ${TOOLS_TO_BUILD} | grep -q "adbd" ; then
+        install -d ${D}${bindir}
+        install -m0755 ${B}/adbd/adbd ${D}${bindir}
+    fi
+
+    # Outside the if statement to avoid errors during do_package
+    install -D -p -m0644 ${WORKDIR}/android-tools-adbd.service \
+      ${D}${systemd_unitdir}/system/android-tools-adbd.service
+
+    install -d  ${D}${libdir}/android/
+    install -m0755 ${S}/debian/out/usr/lib/android/*.so.* ${D}${libdir}/android/
+    if echo ${TOOLS_TO_BUILD} | grep -q "mkbootimg" ; then
+        install -d ${D}${bindir}
+        install -m0755 ${B}/mkbootimg/mkbootimg ${D}${bindir}
+    fi
+}
+
+PACKAGES =+ "${PN}-fstools ${PN}-adbd"
+
+RDEPENDS:${BPN} = "${BPN}-conf p7zip"
+
+FILES:${PN}-adbd = "\
+    ${bindir}/adbd \
+    ${systemd_unitdir}/system/android-tools-adbd.service \
+"
+
+FILES:${PN}-fstools = "\
+    ${bindir}/ext2simg \
+    ${bindir}/ext4fixup \
+    ${bindir}/img2simg \
+    ${bindir}/make_ext4fs \
+    ${bindir}/simg2img \
+    ${bindir}/simg2simg \
+    ${bindir}/simg_dump \
+    ${bindir}/mkuserimg \
+"
+FILES:${PN} += "${libdir}/android ${libdir}/android/*"
+
+BBCLASSEXTEND = "native"
+
+android_tools_enable_devmode() {
+    touch ${IMAGE_ROOTFS}/var/usb-debugging-enabled
+}
+
+ROOTFS_POSTPROCESS_COMMAND_${PN}-adbd += "${@bb.utils.contains("USB_DEBUGGING_ENABLED", "1", "android_tools_enable_devmode;", "", d)}"


### PR DESCRIPTION
The `fastboot` binary we currently ship only works when manually supplied the USB vendor id of the device we want to flash.
This is non-intuitive and newer `fastboot` just finds the right device automagically.

Backport a newer `android-tools` [from meta-oe master](https://github.com/openembedded/meta-openembedded/tree/b71b1ee/meta-oe/dynamic-layers/selinux/recipes-devtool/android-tools) and add `meta-selinux` which provides `libselinux`.

I'm not a fan of adding `meta-selinux` just for `libselinux`, so if there are any other ideas I am open for it.

The addition of the meta layer also means that bblayer templates in custom `meta-lxatac` derived BSPs have to be updated in tandem.