### PR TITLE
meta-lxatac-software: chrony: configure only _one_ pool (of four servers)

### DIFF
--- a/meta-lxatac-software/recipes-support/chrony/files/chrony.conf
+++ b/meta-lxatac-software/recipes-support/chrony/files/chrony.conf
@@ -3,10 +3,7 @@
 # The NTP pool project provides public servers for time synchronization
 # consider joining the pool[1] if you are interested in having a great time.
 # [1]: https://www.pool.ntp.org/join.html
-pool 0.linux-automation.pool.ntp.org iburst
-pool 1.linux-automation.pool.ntp.org iburst
 pool 2.linux-automation.pool.ntp.org iburst
-pool 3.linux-automation.pool.ntp.org iburst
 
 # Use time sources from DHCP.
 sourcedir /run/chrony-dhcp


### PR DESCRIPTION
The chrony [`pool`][1] directive requests a list of servers via DNS and uses (by default) up to four of them for time synchronization. Chrony will also also put new servers into its list if some of the existing ones become unavailable.
This means that configuring four _pools_ will result in chrony talking to sixteen time servers, which is not reasonable.

What we want instead is one pool of four servers.

Why hard-code the `2.`… entry from our vendor pool?
The NTP pool only returns IPv4 addresses for the `0.`, `1.` and `3.` entries, which would break IPv6-only deployments.
This is also what some distributions do. See [this link][2] for a discussion.

[1]: https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#pool
[2]: https://community.ntppool.org/t/the-time-has-come-we-must-enable-ipv6-entirely/1968/52