### PR TITLE
Poll for RAUC updates and show notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Linux Automation GmbH Test Automation Controller Base Image
 
 Main topics:
 
+  - [Installing official Images](#installing-official-images)
   - [Building the image as-is](#building-the-image-as-is)
   - [Customization](#customization)
   - [Installing Images via USB](#installing-images-via-usb)
@@ -11,8 +12,22 @@ This set of recipes is used to build the software images and update bundles
 for the LXATAC provided by the Linux Automation GmbH. It can be used to
 derive customized and pre-configured images for use in your infrastructure.
 
+Installing official Images
+--------------------------
+
+If you came here looking for the most recent software bundle for you LXA TAC
+and have no actual interest in building your own custom bundles (yet) there is
+great news for you. You do not have to follow this long README at all!
+The following command automatically installs the most recent stable software
+bundle on your TAC:
+
+    $ rauc install https://downloads.linux-automation.com/lxatac/software/stable/latest/lxatac-core-bundle-base-lxatac.raucb
+
 Building the image as-is
 ------------------------
+
+This chapter describes building rougly the same RAUC bundles as the ones
+available from the official mirror mentioned above.
 
 > The image building process will compile a lot of software from source code,
 > including the Linux kernel, language interpreters and development tools.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Main topics:
   - [Installing official Images](#installing-official-images)
   - [Building the image as-is](#building-the-image-as-is)
   - [Customization](#customization)
+  - [Setting up a Bundle Server](#bundle-server)
   - [Installing Images via USB](#installing-images-via-usb)
 
 This set of recipes is used to build the software images and update bundles
@@ -338,6 +339,45 @@ the default image:
 A newly built update bundle should now contain your specified ssh keys:
 
     $ bitbake lxatac-core-bundle-base
+
+Setting up a Bundle Server
+--------------------------
+
+Now that you have built your own custom RAUC bundles you may want to deploy
+them via your own update bundle server.
+For that to work you only need a normal HTTP server that you can deploy your
+most recent `.raucb` bundles to and two small bits of configuration in your
+OS images.
+
+    $ mkdir -p meta-lxatac-example/recipes-rust/tacd/files/
+    $ cat > meta-lxatac-example/recipes-rust/tacd/files/02_example.yaml <<EOF
+    name: example
+    display_name: Example
+    description: |
+      An update channel created for exemplary purposes only.
+    url: |
+      http://YOUR_SERVERS_HOSTNAME/PATH_TO_THE.raucb
+    polling_interval: "24h"
+    EOF
+    $ cat > meta-lxatac-example/recipes-rust/tacd/tacd_%.bbappend <<EOF
+    FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+    SRC_URI += "\
+        file://02_example.yaml \
+        "
+
+    do_install:append() {
+        install -D -m 0644 ${WORKDIR}/02_example.yaml \
+            ${D}${datadir}/tacd/update_channels/02_example.yaml
+    }
+    EOF
+
+Replace `YOUR_SERVERS_HOSTNAME` and `PATH_TO_THE.raucb` according to your
+servers location and the location of the bundle on the server.
+Make sure the configured `name` matches the name of the certificate file you
+have generated, e.g. `example.cert.pem` in this example, as the existence of
+said certificates in the `certificates-enabled` directory determines if an
+update channel is considered active.
 
 Installing Images via USB
 -------------------------

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ You can now paste the following recipe to
 Next you want to tell bitbake to build the recipe and install the result to
 the default image:
 
-    $ mkdir -p meta-lxatac-ptx/recipes-core/images
-    $ cat > meta-lxatac-ptx/recipes-core/images/lxatac-core-image-base.bbappend <<EOF
+    $ mkdir -p meta-lxatac-example/recipes-core/images
+    $ cat > meta-lxatac-example/recipes-core/images/lxatac-core-image-base.bbappend <<EOF
     IMAGE_INSTALL:append = "\
         ssh-keys \
     "

--- a/meta-lxatac-bsp/recipes-core/rauc/files/rauc-disable-cert.sh
+++ b/meta-lxatac-bsp/recipes-core/rauc/files/rauc-disable-cert.sh
@@ -21,3 +21,5 @@ rm "$ENABLED_DIR/$1"
 
 openssl rehash "$ENABLED_DIR"
 
+# Ask the tacd to update the list of channels
+curl -X PUT -d "true" "http://localhost/v1/tac/update/channels/reload"

--- a/meta-lxatac-bsp/recipes-core/rauc/files/rauc-enable-cert.sh
+++ b/meta-lxatac-bsp/recipes-core/rauc/files/rauc-enable-cert.sh
@@ -25,3 +25,5 @@ fi
 ln -s "../certificates-available/$1" "$ENABLED_DIR/$1"
 openssl rehash "$ENABLED_DIR"
 
+# Ask the tacd to update the list of channels
+curl -X PUT -d "true" "http://localhost/v1/tac/update/channels/reload"

--- a/meta-lxatac-software/recipes-rust/tacd/files/01_stable.yaml
+++ b/meta-lxatac-software/recipes-rust/tacd/files/01_stable.yaml
@@ -1,0 +1,9 @@
+name: stable
+display_name: Stable
+description: |
+  Official updates bundles provided by the Linux Automation GmbH.
+  The released bundles are manually tested and signed before publication.
+url: |
+  https://downloads.linux-automation.com/lxatac/software/stable/latest/lxatac-core-bundle-base-lxatac.raucb
+polling_interval: "4d"
+

--- a/meta-lxatac-software/recipes-rust/tacd/files/05_testing.yaml
+++ b/meta-lxatac-software/recipes-rust/tacd/files/05_testing.yaml
@@ -1,0 +1,10 @@
+name: testing
+display_name: Testing
+description: |
+  Testing bundles provided by the Linux Automation GmbH.
+  The released bundles are automatically tested on actual hardware and automatically uploaded.
+  Receives more frequent but less stable updates than the Stable channel.
+url: |
+  https://downloads.linux-automation.com/lxatac/software/testing/latest/lxatac-core-bundle-base-lxatac.raucb
+polling_interval: "24h"
+

--- a/meta-lxatac-software/recipes-rust/tacd/tacd.inc
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd.inc
@@ -2,6 +2,8 @@ SRC_URI += " \
     file://tacd.service \
     file://tacd-failsafe.sh \
     file://de.pengutronix.tacd.conf \
+    file://01_stable.yaml \
+    file://05_testing.yaml \
     "
 
 inherit pkgconfig
@@ -16,6 +18,9 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/tacd.service ${D}${systemd_system_unitdir}/
 
     install -D -m 0755 ${WORKDIR}/tacd-failsafe.sh ${D}${bindir}/tacd-failsafe
+
+    install -D -m 0644 ${WORKDIR}/01_stable.yaml ${D}${datadir}/tacd/update_channels/01_stable.yaml
+    install -D -m 0644 ${WORKDIR}/05_testing.yaml ${D}${datadir}/tacd/update_channels/05_testing.yaml
 
     install -d ${D}${sysconfdir}/dbus-1/system.d
     install -m 0644 ${WORKDIR}/de.pengutronix.tacd.conf ${D}/${sysconfdir}/dbus-1/system.d/

--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "8232cf2d6b4cf66bd949214c2cde8a5a8dbb2fd8"
+SRCREV = "88d20f145ea27d0af39cd412a6f51b2f514ca254"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"
@@ -15,31 +15,31 @@ SRC_URI += " \
     crate://crates.io/aes-soft/0.6.4 \
     crate://crates.io/aes/0.6.0 \
     crate://crates.io/aesni/0.10.0 \
-    crate://crates.io/aho-corasick/0.7.20 \
+    crate://crates.io/aho-corasick/1.0.1 \
     crate://crates.io/android_system_properties/0.1.5 \
-    crate://crates.io/anyhow/1.0.69 \
-    crate://crates.io/arrayref/0.3.6 \
+    crate://crates.io/anyhow/1.0.71 \
+    crate://crates.io/arrayref/0.3.7 \
     crate://crates.io/arrayvec/0.5.2 \
     crate://crates.io/async-attributes/1.1.2 \
     crate://crates.io/async-broadcast/0.5.1 \
     crate://crates.io/async-channel/1.8.0 \
     crate://crates.io/async-dup/1.2.2 \
-    crate://crates.io/async-executor/1.5.0 \
+    crate://crates.io/async-executor/1.5.1 \
     crate://crates.io/async-fs/1.6.0 \
     crate://crates.io/async-global-executor/2.3.1 \
     crate://crates.io/async-h1/2.3.3 \
-    crate://crates.io/async-io/1.12.0 \
+    crate://crates.io/async-io/1.13.0 \
     crate://crates.io/async-lock/2.7.0 \
-    crate://crates.io/async-process/1.6.0 \
-    crate://crates.io/async-recursion/1.0.2 \
+    crate://crates.io/async-process/1.7.0 \
+    crate://crates.io/async-recursion/1.0.4 \
     crate://crates.io/async-session/2.0.1 \
     crate://crates.io/async-sse/4.1.0 \
     crate://crates.io/async-sse/5.1.0 \
     crate://crates.io/async-std/1.12.0 \
-    crate://crates.io/async-task/4.3.0 \
-    crate://crates.io/async-trait/0.1.66 \
+    crate://crates.io/async-task/4.4.0 \
+    crate://crates.io/async-trait/0.1.68 \
     crate://crates.io/async-tungstenite/0.20.0 \
-    crate://crates.io/atomic-waker/1.1.0 \
+    crate://crates.io/atomic-waker/1.1.1 \
     crate://crates.io/autocfg/1.1.0 \
     crate://crates.io/az/1.2.1 \
     crate://crates.io/base-x/0.2.11 \
@@ -52,9 +52,9 @@ SRC_URI += " \
     crate://crates.io/blake3/0.3.8 \
     crate://crates.io/block-buffer/0.10.4 \
     crate://crates.io/block-buffer/0.9.0 \
-    crate://crates.io/blocking/1.3.0 \
+    crate://crates.io/blocking/1.3.1 \
     crate://crates.io/build-env/0.3.1 \
-    crate://crates.io/bumpalo/3.12.0 \
+    crate://crates.io/bumpalo/3.12.2 \
     crate://crates.io/byteorder/1.4.3 \
     crate://crates.io/bytes/1.4.0 \
     crate://crates.io/cc/1.0.79 \
@@ -63,13 +63,13 @@ SRC_URI += " \
     crate://crates.io/chrono/0.4.24 \
     crate://crates.io/cipher/0.2.5 \
     crate://crates.io/codespan-reporting/0.11.1 \
-    crate://crates.io/concurrent-queue/2.1.0 \
+    crate://crates.io/concurrent-queue/2.2.0 \
     crate://crates.io/config/0.10.1 \
     crate://crates.io/const_fn/0.4.9 \
     crate://crates.io/constant_time_eq/0.1.5 \
     crate://crates.io/cookie/0.14.4 \
-    crate://crates.io/core-foundation-sys/0.8.3 \
-    crate://crates.io/cpufeatures/0.2.5 \
+    crate://crates.io/core-foundation-sys/0.8.4 \
+    crate://crates.io/cpufeatures/0.2.7 \
     crate://crates.io/cpuid-bool/0.2.0 \
     crate://crates.io/crc32fast/1.3.2 \
     crate://crates.io/crossbeam-queue/0.3.8 \
@@ -80,52 +80,52 @@ SRC_URI += " \
     crate://crates.io/cstr-argument/0.1.2 \
     crate://crates.io/ctor/0.1.26 \
     crate://crates.io/ctr/0.6.0 \
-    crate://crates.io/cxx-build/1.0.92 \
-    crate://crates.io/cxx/1.0.92 \
-    crate://crates.io/cxxbridge-flags/1.0.92 \
-    crate://crates.io/cxxbridge-macro/1.0.92 \
+    crate://crates.io/cxx-build/1.0.94 \
+    crate://crates.io/cxx/1.0.94 \
+    crate://crates.io/cxxbridge-flags/1.0.94 \
+    crate://crates.io/cxxbridge-macro/1.0.94 \
     crate://crates.io/dashmap/5.4.0 \
     crate://crates.io/deadpool/0.7.0 \
     crate://crates.io/derivative/2.2.0 \
     crate://crates.io/digest/0.10.6 \
     crate://crates.io/digest/0.9.0 \
-    crate://crates.io/dirs-sys/0.3.7 \
-    crate://crates.io/dirs/4.0.0 \
     crate://crates.io/discard/1.0.4 \
     crate://crates.io/embedded-graphics-core/0.3.3 \
     crate://crates.io/embedded-graphics/0.7.1 \
-    crate://crates.io/enumflags2/0.7.5 \
-    crate://crates.io/enumflags2_derive/0.7.4 \
+    crate://crates.io/enumflags2/0.7.7 \
+    crate://crates.io/enumflags2_derive/0.7.7 \
     crate://crates.io/env_logger/0.10.0 \
     crate://crates.io/erased-serde/0.3.25 \
     crate://crates.io/errno-dragonfly/0.1.2 \
     crate://crates.io/errno/0.2.8 \
+    crate://crates.io/errno/0.3.1 \
     crate://crates.io/evdev/0.12.1 \
     crate://crates.io/event-listener/2.5.3 \
     crate://crates.io/fastrand/1.9.0 \
+    crate://crates.io/fdeflate/0.3.0 \
     crate://crates.io/femme/2.2.1 \
-    crate://crates.io/flate2/1.0.25 \
+    crate://crates.io/flate2/1.0.26 \
     crate://crates.io/float-cmp/0.8.0 \
     crate://crates.io/fnv/1.0.7 \
-    crate://crates.io/foreign-types-macros/0.2.2 \
+    crate://crates.io/foreign-types-macros/0.2.3 \
     crate://crates.io/foreign-types-shared/0.3.1 \
     crate://crates.io/foreign-types/0.5.0 \
     crate://crates.io/form_urlencoded/1.1.0 \
     crate://crates.io/framebuffer/0.3.1 \
     crate://crates.io/funty/2.0.0 \
-    crate://crates.io/futures-channel/0.3.27 \
-    crate://crates.io/futures-core/0.3.27 \
-    crate://crates.io/futures-executor/0.3.27 \
-    crate://crates.io/futures-io/0.3.27 \
-    crate://crates.io/futures-lite/1.12.0 \
-    crate://crates.io/futures-macro/0.3.27 \
-    crate://crates.io/futures-sink/0.3.27 \
-    crate://crates.io/futures-task/0.3.27 \
-    crate://crates.io/futures-util/0.3.27 \
-    crate://crates.io/futures/0.3.27 \
-    crate://crates.io/generic-array/0.14.6 \
+    crate://crates.io/futures-channel/0.3.28 \
+    crate://crates.io/futures-core/0.3.28 \
+    crate://crates.io/futures-executor/0.3.28 \
+    crate://crates.io/futures-io/0.3.28 \
+    crate://crates.io/futures-lite/1.13.0 \
+    crate://crates.io/futures-macro/0.3.28 \
+    crate://crates.io/futures-sink/0.3.28 \
+    crate://crates.io/futures-task/0.3.28 \
+    crate://crates.io/futures-util/0.3.28 \
+    crate://crates.io/futures/0.3.28 \
+    crate://crates.io/generic-array/0.14.7 \
     crate://crates.io/getrandom/0.1.16 \
-    crate://crates.io/getrandom/0.2.8 \
+    crate://crates.io/getrandom/0.2.9 \
     crate://crates.io/ghash/0.3.1 \
     crate://crates.io/gloo-timers/0.2.6 \
     crate://crates.io/gpio-cdev/0.5.1 \
@@ -142,24 +142,24 @@ SRC_URI += " \
     crate://crates.io/httparse/1.8.0 \
     crate://crates.io/humantime/2.1.0 \
     crate://crates.io/iana-time-zone-haiku/0.1.1 \
-    crate://crates.io/iana-time-zone/0.1.53 \
+    crate://crates.io/iana-time-zone/0.1.56 \
     crate://crates.io/idna/0.3.0 \
-    crate://crates.io/indexmap/1.9.2 \
+    crate://crates.io/indexmap/1.9.3 \
     crate://crates.io/industrial-io/0.5.2 \
     crate://crates.io/infer/0.2.3 \
     crate://crates.io/instant/0.1.12 \
-    crate://crates.io/io-lifetimes/1.0.6 \
-    crate://crates.io/is-terminal/0.4.4 \
+    crate://crates.io/io-lifetimes/1.0.10 \
+    crate://crates.io/is-terminal/0.4.7 \
     crate://crates.io/itoa/1.0.6 \
-    crate://crates.io/js-sys/0.3.61 \
+    crate://crates.io/js-sys/0.3.62 \
     crate://crates.io/kv-log-macro/1.0.7 \
     crate://crates.io/lazy_static/1.4.0 \
     crate://crates.io/lexical-core/0.7.6 \
-    crate://crates.io/libc/0.2.140 \
+    crate://crates.io/libc/0.2.144 \
     crate://crates.io/libiio-sys/0.3.1 \
     crate://crates.io/libsystemd-sys/0.9.3 \
     crate://crates.io/link-cplusplus/1.0.8 \
-    crate://crates.io/linux-raw-sys/0.1.4 \
+    crate://crates.io/linux-raw-sys/0.3.7 \
     crate://crates.io/lock_api/0.4.9 \
     crate://crates.io/log/0.4.17 \
     crate://crates.io/memchr/2.5.0 \
@@ -167,13 +167,13 @@ SRC_URI += " \
     crate://crates.io/memoffset/0.6.5 \
     crate://crates.io/memoffset/0.7.1 \
     crate://crates.io/micromath/1.1.1 \
-    crate://crates.io/mime/0.3.16 \
+    crate://crates.io/mime/0.3.17 \
     crate://crates.io/mime_guess/2.0.4 \
-    crate://crates.io/miniz_oxide/0.6.2 \
+    crate://crates.io/miniz_oxide/0.7.1 \
     crate://crates.io/mqtt-protocol/0.11.2 \
     crate://crates.io/nix/0.23.2 \
     crate://crates.io/nix/0.26.2 \
-    crate://crates.io/nom/5.1.2 \
+    crate://crates.io/nom/5.1.3 \
     crate://crates.io/num-integer/0.1.45 \
     crate://crates.io/num-traits/0.2.15 \
     crate://crates.io/num_cpus/1.15.0 \
@@ -181,7 +181,7 @@ SRC_URI += " \
     crate://crates.io/once_cell/1.17.1 \
     crate://crates.io/opaque-debug/0.3.0 \
     crate://crates.io/ordered-stream/0.2.0 \
-    crate://crates.io/parking/2.0.0 \
+    crate://crates.io/parking/2.1.0 \
     crate://crates.io/parking_lot_core/0.9.7 \
     crate://crates.io/percent-encoding/2.2.0 \
     crate://crates.io/pin-project-internal/1.0.12 \
@@ -189,15 +189,15 @@ SRC_URI += " \
     crate://crates.io/pin-project-lite/0.2.9 \
     crate://crates.io/pin-project/1.0.12 \
     crate://crates.io/pin-utils/0.1.0 \
-    crate://crates.io/pkg-config/0.3.26 \
-    crate://crates.io/png/0.17.7 \
-    crate://crates.io/polling/2.6.0 \
+    crate://crates.io/pkg-config/0.3.27 \
+    crate://crates.io/png/0.17.8 \
+    crate://crates.io/polling/2.8.0 \
     crate://crates.io/polyval/0.4.5 \
     crate://crates.io/ppv-lite86/0.2.17 \
     crate://crates.io/proc-macro-crate/1.3.1 \
     crate://crates.io/proc-macro-hack/0.5.20+deprecated \
-    crate://crates.io/proc-macro2/1.0.52 \
-    crate://crates.io/quote/1.0.26 \
+    crate://crates.io/proc-macro2/1.0.56 \
+    crate://crates.io/quote/1.0.27 \
     crate://crates.io/radium/0.7.0 \
     crate://crates.io/rand/0.7.3 \
     crate://crates.io/rand/0.8.5 \
@@ -207,26 +207,26 @@ SRC_URI += " \
     crate://crates.io/rand_core/0.6.4 \
     crate://crates.io/rand_hc/0.2.0 \
     crate://crates.io/redox_syscall/0.2.16 \
-    crate://crates.io/redox_users/0.4.3 \
-    crate://crates.io/regex-syntax/0.6.28 \
-    crate://crates.io/regex/1.7.1 \
+    crate://crates.io/redox_syscall/0.3.5 \
+    crate://crates.io/regex-syntax/0.7.1 \
+    crate://crates.io/regex/1.8.1 \
     crate://crates.io/route-recognizer/0.2.0 \
     crate://crates.io/rustc_version/0.2.3 \
-    crate://crates.io/rustix/0.36.9 \
+    crate://crates.io/rustix/0.37.19 \
     crate://crates.io/rustversion/1.0.12 \
     crate://crates.io/ryu/1.0.13 \
     crate://crates.io/scopeguard/1.1.0 \
     crate://crates.io/scratch/1.0.5 \
     crate://crates.io/semver-parser/0.7.0 \
     crate://crates.io/semver/0.9.0 \
-    crate://crates.io/serde/1.0.156 \
-    crate://crates.io/serde_derive/1.0.156 \
-    crate://crates.io/serde_fmt/1.0.1 \
-    crate://crates.io/serde_json/1.0.94 \
+    crate://crates.io/serde/1.0.162 \
+    crate://crates.io/serde_derive/1.0.162 \
+    crate://crates.io/serde_fmt/1.0.3 \
+    crate://crates.io/serde_json/1.0.96 \
     crate://crates.io/serde_qs/0.8.5 \
-    crate://crates.io/serde_repr/0.1.11 \
+    crate://crates.io/serde_repr/0.1.12 \
     crate://crates.io/serde_urlencoded/0.7.1 \
-    crate://crates.io/serde_yaml/0.9.19 \
+    crate://crates.io/serde_yaml/0.9.21 \
     crate://crates.io/sha-1/0.10.1 \
     crate://crates.io/sha1/0.10.5 \
     crate://crates.io/sha1/0.6.1 \
@@ -234,6 +234,7 @@ SRC_URI += " \
     crate://crates.io/sha2/0.9.9 \
     crate://crates.io/signal-hook-registry/1.4.1 \
     crate://crates.io/signal-hook/0.3.15 \
+    crate://crates.io/simd-adler32/0.3.5 \
     crate://crates.io/simple-mutex/1.1.5 \
     crate://crates.io/slab/0.4.8 \
     crate://crates.io/smallvec/1.10.0 \
@@ -248,13 +249,14 @@ SRC_URI += " \
     crate://crates.io/surf/2.3.2 \
     crate://crates.io/sval/1.0.0-alpha.5 \
     crate://crates.io/syn/1.0.109 \
+    crate://crates.io/syn/2.0.15 \
     crate://crates.io/sysfs-class/0.1.3 \
     crate://crates.io/systemd/0.10.0 \
     crate://crates.io/tap/1.0.1 \
-    crate://crates.io/tempfile/3.4.0 \
+    crate://crates.io/tempfile/3.5.0 \
     crate://crates.io/termcolor/1.2.0 \
-    crate://crates.io/thiserror-impl/1.0.39 \
-    crate://crates.io/thiserror/1.0.39 \
+    crate://crates.io/thiserror-impl/1.0.40 \
+    crate://crates.io/thiserror/1.0.40 \
     crate://crates.io/thread-priority/0.13.1 \
     crate://crates.io/tide/0.16.0 \
     crate://crates.io/time-macros-impl/0.1.2 \
@@ -263,23 +265,23 @@ SRC_URI += " \
     crate://crates.io/time/0.2.27 \
     crate://crates.io/tinyvec/1.6.0 \
     crate://crates.io/tinyvec_macros/0.1.1 \
-    crate://crates.io/tokio/1.26.0 \
+    crate://crates.io/tokio/1.28.0 \
     crate://crates.io/toml_datetime/0.6.1 \
-    crate://crates.io/toml_edit/0.19.7 \
-    crate://crates.io/tracing-attributes/0.1.23 \
+    crate://crates.io/toml_edit/0.19.8 \
+    crate://crates.io/tracing-attributes/0.1.24 \
     crate://crates.io/tracing-core/0.1.30 \
     crate://crates.io/tracing/0.1.37 \
     crate://crates.io/tungstenite/0.18.0 \
     crate://crates.io/typenum/1.16.0 \
     crate://crates.io/uds_windows/1.0.2 \
     crate://crates.io/unicase/2.6.0 \
-    crate://crates.io/unicode-bidi/0.3.11 \
+    crate://crates.io/unicode-bidi/0.3.13 \
     crate://crates.io/unicode-ident/1.0.8 \
     crate://crates.io/unicode-normalization/0.1.22 \
     crate://crates.io/unicode-width/0.1.10 \
     crate://crates.io/unique-token/0.2.0 \
     crate://crates.io/universal-hash/0.4.1 \
-    crate://crates.io/unsafe-libyaml/0.2.7 \
+    crate://crates.io/unsafe-libyaml/0.2.8 \
     crate://crates.io/url/2.3.1 \
     crate://crates.io/utf-8/0.7.6 \
     crate://crates.io/utf8-cstr/0.1.6 \
@@ -289,31 +291,41 @@ SRC_URI += " \
     crate://crates.io/wasi/0.10.0+wasi-snapshot-preview1 \
     crate://crates.io/wasi/0.11.0+wasi-snapshot-preview1 \
     crate://crates.io/wasi/0.9.0+wasi-snapshot-preview1 \
-    crate://crates.io/wasm-bindgen-backend/0.2.84 \
-    crate://crates.io/wasm-bindgen-futures/0.4.34 \
-    crate://crates.io/wasm-bindgen-macro-support/0.2.84 \
-    crate://crates.io/wasm-bindgen-macro/0.2.84 \
-    crate://crates.io/wasm-bindgen-shared/0.2.84 \
-    crate://crates.io/wasm-bindgen/0.2.84 \
-    crate://crates.io/web-sys/0.3.61 \
+    crate://crates.io/wasm-bindgen-backend/0.2.85 \
+    crate://crates.io/wasm-bindgen-futures/0.4.35 \
+    crate://crates.io/wasm-bindgen-macro-support/0.2.85 \
+    crate://crates.io/wasm-bindgen-macro/0.2.85 \
+    crate://crates.io/wasm-bindgen-shared/0.2.85 \
+    crate://crates.io/wasm-bindgen/0.2.85 \
+    crate://crates.io/web-sys/0.3.62 \
     crate://crates.io/winapi-i686-pc-windows-gnu/0.4.0 \
     crate://crates.io/winapi-util/0.1.5 \
     crate://crates.io/winapi-x86_64-pc-windows-gnu/0.4.0 \
     crate://crates.io/winapi/0.3.9 \
-    crate://crates.io/windows-sys/0.42.0 \
     crate://crates.io/windows-sys/0.45.0 \
+    crate://crates.io/windows-sys/0.48.0 \
     crate://crates.io/windows-targets/0.42.2 \
+    crate://crates.io/windows-targets/0.48.0 \
+    crate://crates.io/windows/0.48.0 \
     crate://crates.io/windows_aarch64_gnullvm/0.42.2 \
+    crate://crates.io/windows_aarch64_gnullvm/0.48.0 \
     crate://crates.io/windows_aarch64_msvc/0.42.2 \
+    crate://crates.io/windows_aarch64_msvc/0.48.0 \
     crate://crates.io/windows_i686_gnu/0.42.2 \
+    crate://crates.io/windows_i686_gnu/0.48.0 \
     crate://crates.io/windows_i686_msvc/0.42.2 \
+    crate://crates.io/windows_i686_msvc/0.48.0 \
     crate://crates.io/windows_x86_64_gnu/0.42.2 \
+    crate://crates.io/windows_x86_64_gnu/0.48.0 \
     crate://crates.io/windows_x86_64_gnullvm/0.42.2 \
+    crate://crates.io/windows_x86_64_gnullvm/0.48.0 \
     crate://crates.io/windows_x86_64_msvc/0.42.2 \
-    crate://crates.io/winnow/0.3.6 \
+    crate://crates.io/windows_x86_64_msvc/0.48.0 \
+    crate://crates.io/winnow/0.4.1 \
     crate://crates.io/wyz/0.5.1 \
-    crate://crates.io/zbus/3.11.0 \
-    crate://crates.io/zbus_macros/3.11.0 \
+    crate://crates.io/xdg-home/1.0.0 \
+    crate://crates.io/zbus/3.12.0 \
+    crate://crates.io/zbus_macros/3.12.0 \
     crate://crates.io/zbus_names/2.5.0 \
     crate://crates.io/zvariant/3.12.0 \
     crate://crates.io/zvariant_derive/3.12.0 \

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -4,7 +4,7 @@ SRC_URI = " \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "8232cf2d6b4cf66bd949214c2cde8a5a8dbb2fd8"
+SRCREV = "88d20f145ea27d0af39cd412a6f51b2f514ca254"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This PR adds operating system update handling to meta-lxatac.

See linux-automation/tacd#19 for what this means.

Open tasks
--------------

- [x] Update the README with information on how to add an update channel.
- [x] Check if #9 can be updated and merged now.

Related Pull Requests
---------------

This PR depends on the following other PRs which should be merged first:

- [x] The `tacd` PR this feature is built on linux-automation/tacd#19.
- [x] The `tacd` PR that updates the dependencies linux-automation/tacd#20.
- [x] The `meta-lxatac` PR that adds Gen 2 support as the new `tacd` uses the larger display #33.
- [x] The `meta-lxatac` PR that adds RAUC certificate directory support #37.