### PR TITLE
meta-lxatac-software/labgrid: Export USB-Ports as Power Switches

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -44,6 +44,15 @@ dut_power:
     host: 'http://{{ hostname }}/v1/dut/powered/compat'
     index: '0'   # this is 'don't care'
 
+## Set up power switching for the USB ports on the LXA TAC
+{% for idx in range(1,4) %}
+lxatac-usb-power-p{{idx}}:
+  USBPowerPort:
+    match:
+      ID_PATH: platform-5800d000.usb-usb-0:1:1.0
+    index: {{idx}}
+{% endfor %}
+
 ## Set up USB ports after including user configuration to allow
 ## e.g. hub configuration
 {% for idx, sysfs in usb.ports %}


### PR DESCRIPTION
All three USB ports on the LXA TAC are power switchable (e.g. using `uhubctl`).
`labgrid` already has a driver that can handle ports where power can be switched: `USBPowerPort`.

With this change we'll export the three USB ports as power ports. This way they can be used to switch DUTs on or off.

The resources exported will look something like this:
```
$ labgrid-client r
lxatac-00013/dut_power/NetworkPowerPort
lxatac-00013/lxatac-usb-ports-power-p1/NetworkUSBPowerPort  # <-- new
lxatac-00013/lxatac-usb-ports-power-p2/NetworkUSBPowerPort  # <-- new
lxatac-00013/lxatac-usb-ports-power-p3/NetworkUSBPowerPort  # <-- new
lxatac-00013/serial/NetworkSerialPort
```