### PR TITLE
Do not clutter the rootfs's /srv on first boot

### DIFF
--- a/meta-lxatac-bsp/conf/machine/lxatac.conf
+++ b/meta-lxatac-bsp/conf/machine/lxatac.conf
@@ -33,8 +33,7 @@ KERNEL_DEVICETREE = "stm32mp157c-lxa-tac-gen1.dtb stm32mp157c-lxa-tac-gen2.dtb"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-modules"
 
 # we want some more helper features for development
-EXTRA_IMAGE_FEATURES += "empty-root-password \
-			"
+EXTRA_IMAGE_FEATURES += "empty-root-password"
 
 MACHINE_FEATURES = "serial ext2 rtc usbhost usbgadget"
 

--- a/meta-lxatac-bsp/conf/machine/lxatac.conf
+++ b/meta-lxatac-bsp/conf/machine/lxatac.conf
@@ -35,6 +35,10 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-modules"
 # we want some more helper features for development
 EXTRA_IMAGE_FEATURES += "empty-root-password"
 
+# Don't symlink /var/log to /var/log/volatile as we do actually want
+# persistent logging.
+VOLATILE_LOG_DIR = "no"
+
 MACHINE_FEATURES = "serial ext2 rtc usbhost usbgadget"
 
 SOC_FAMILY = "stm32mp1"

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/use-var-volatile-log-journal.conf
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/use-var-volatile-log-journal.conf
@@ -1,2 +1,0 @@
-[Unit]
-RequiresMountsFor=/var/volatile/log/journal

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/var-log-journal.mount
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/var-log-journal.mount
@@ -1,0 +1,5 @@
+[Mount]
+Where=/var/log/journal
+What=/srv/journal
+Type=none
+Options=bind

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/var-volatile-log-journal.mount
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/files/var-volatile-log-journal.mount
@@ -1,8 +1,0 @@
-[Unit]
-Before=local-fs.target
-
-[Mount]
-Where=/var/volatile/log/journal
-What=/srv/journal
-Type=none
-Options=bind

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/lxatac-persistent-journal.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-journal/lxatac-persistent-journal.bb
@@ -1,23 +1,15 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-# Because /var/log is symlinked to /var/volatile/log, we need to have a
-# separate mount unit for the bind mount and a snippet for
-# systemd-journal-flush.service.
-
 SRC_URI = " \
-    file://var-volatile-log-journal.mount \
-    file://use-var-volatile-log-journal.conf \
+    file://var-log-journal.mount \
 "
 
 S = "${WORKDIR}"
 
 do_install () {
     install -d ${D}${systemd_system_unitdir}/
-    install -m 0644 -t ${D}${systemd_system_unitdir}/ ${S}/var-volatile-log-journal.mount
-    install -d ${D}${systemd_system_unitdir}/systemd-journal-flush.service.d/
-    install -m 0644 -t ${D}${systemd_system_unitdir}/systemd-journal-flush.service.d/ \
-        ${S}/use-var-volatile-log-journal.conf
+    install -m 0644 -t ${D}${systemd_system_unitdir}/ ${S}/var-log-journal.mount
 }
 
 FILES:${PN} = "${systemd_system_unitdir}"

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-labgrid-cache/files/var-cache-labgrid.mount
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-labgrid-cache/files/var-cache-labgrid.mount
@@ -1,6 +1,3 @@
-[Unit]
-Before=local-fs.target
-
 [Mount]
 Where=/var/cache/labgrid
 What=/srv/cache/labgrid

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/use-var-log-sa.conf
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/use-var-log-sa.conf
@@ -1,0 +1,2 @@
+[Unit]
+RequiresMountsFor=/var/log/sa

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/use-var-volatile-log-sa.conf
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/use-var-volatile-log-sa.conf
@@ -1,2 +1,0 @@
-[Unit]
-RequiresMountsFor=/var/volatile/log/sa

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/var-log-sa.mount
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/var-log-sa.mount
@@ -1,0 +1,5 @@
+[Mount]
+Where=/var/log/sa
+What=/srv/sysstat
+Type=none
+Options=bind

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/var-volatile-log-sa.mount
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/files/var-volatile-log-sa.mount
@@ -1,8 +1,0 @@
-[Unit]
-Before=local-fs.target
-
-[Mount]
-Where=/var/volatile/log/sa
-What=/srv/sysstat
-Type=none
-Options=bind

--- a/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/lxatac-persistent-sysstat.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-persistent-sysstat/lxatac-persistent-sysstat.bb
@@ -1,23 +1,19 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-# Because /var/log is symlinked to /var/volatile/log, we need to have a
-# separate mount unit for the bind mount and a snippet for
-# sysstat.service.
-
 SRC_URI = " \
-    file://var-volatile-log-sa.mount \
-    file://use-var-volatile-log-sa.conf \
+    file://var-log-sa.mount \
+    file://use-var-log-sa.conf \
 "
 
 S = "${WORKDIR}"
 
 do_install () {
     install -d ${D}${systemd_system_unitdir}/
-    install -m 0644 -t ${D}${systemd_system_unitdir}/ ${S}/var-volatile-log-sa.mount
+    install -m 0644 -t ${D}${systemd_system_unitdir}/ ${S}/var-log-sa.mount
     install -d ${D}${systemd_system_unitdir}/sysstat.service.d/
     install -m 0644 -t ${D}${systemd_system_unitdir}/sysstat.service.d/ \
-        ${S}/use-var-volatile-log-sa.conf
+        ${S}/use-var-log-sa.conf
 }
 
 FILES:${PN} = "${systemd_system_unitdir}"

--- a/meta-lxatac-bsp/recipes-core/lxatac-repart/files/ordering.conf
+++ b/meta-lxatac-bsp/recipes-core/lxatac-repart/files/ordering.conf
@@ -1,3 +1,4 @@
 [Unit]
 Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service
+Before=system-update.target

--- a/meta-lxatac-bsp/recipes-core/lxatac-repart/lxatac-repart.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-repart/lxatac-repart.bb
@@ -13,9 +13,18 @@ do_install () {
     install -m 0644 -t ${D}${libdir}/systemd/system/systemd-repart.service.d/ ${S}/*.conf
     install -d ${D}${libdir}/repart.d/
     install -m 0644 -t ${D}${libdir}/repart.d/ ${S}/repart.d/*
+
+    # The presence of a /system-update file/symlink is checked by
+    # systemd-system-update-generator.
+    # If it exists the boot process is redirected to system-update.target
+    # instead of default.target.
+    # This allows us to repart the eMMC without interference from other
+    # services.
+    touch ${D}/system-update
 }
 
 FILES:${PN} = " \
+    /system-update \
     ${libdir}/repart.d \
     ${libdir}/systemd/system/systemd-repart.service.d \
     "

--- a/meta-lxatac-bsp/recipes-core/lxatac-repart/lxatac-repart.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-repart/lxatac-repart.bb
@@ -4,16 +4,19 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
     file://repart.d \
     file://ordering.conf \
-	   "
+    "
 
 S = "${WORKDIR}"
 
 do_install () {
-        install -d ${D}${libdir}/systemd/system/systemd-repart.service.d/
-        install -m 0644 -t ${D}${libdir}/systemd/system/systemd-repart.service.d/ ${S}/*.conf
-        install -d ${D}${libdir}/repart.d/
-        install -m 0644 -t ${D}${libdir}/repart.d/ ${S}/repart.d/*
+    install -d ${D}${libdir}/systemd/system/systemd-repart.service.d/
+    install -m 0644 -t ${D}${libdir}/systemd/system/systemd-repart.service.d/ ${S}/*.conf
+    install -d ${D}${libdir}/repart.d/
+    install -m 0644 -t ${D}${libdir}/repart.d/ ${S}/repart.d/*
 }
 
-FILES:${PN} = "${libdir}/repart.d ${libdir}/systemd/system/systemd-repart.service.d"
+FILES:${PN} = " \
+    ${libdir}/repart.d \
+    ${libdir}/systemd/system/systemd-repart.service.d \
+    "
 

--- a/meta-lxatac-bsp/recipes-core/rauc/files/require-mount-srv.conf
+++ b/meta-lxatac-bsp/recipes-core/rauc/files/require-mount-srv.conf
@@ -1,0 +1,3 @@
+[Unit]
+RequiresMountsFor=/srv/rauc
+

--- a/meta-lxatac-bsp/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/rauc/rauc_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 RDEPENDS:${PN}:append = "bash"
 
 SRC_URI:append = " \
+    file://require-mount-srv.conf \
     file://rauc-disable-cert.sh \
     file://rauc-enable-cert.sh \
     file://devel.cert.pem \
@@ -11,6 +12,9 @@ SRC_URI:append = " \
     "
 
 do_install:append() {
+    install -D -m 0644 ${WORKDIR}/require-mount-srv.conf \
+        ${D}${systemd_unitdir}/system/rauc.service.d/require-mount-srv.conf
+
     install -D -m 0755 ${WORKDIR}/rauc-disable-cert.sh \
         ${D}${bindir}/rauc-disable-cert
 
@@ -48,3 +52,5 @@ do_install:append() {
 
     openssl rehash ${D}${sysconfdir}/rauc/certificates-enabled
 }
+
+FILES:${PN} += "${systemd_unitdir}/system/rauc.service.d/"

--- a/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
@@ -1,4 +1,4 @@
-RRECOMMENDS:${PN}:append = " less"
+RRECOMMENDS:${PN}:append = "less"
 # Enable lz4 and seccomp for systemd
-PACKAGECONFIG:append = " lz4 seccomp coredump elfutils"
+PACKAGECONFIG:append = "lz4 seccomp coredump elfutils"
 PACKAGECONFIG:remove = "networkd"

--- a/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
@@ -2,3 +2,16 @@ RRECOMMENDS:${PN}:append = "less"
 # Enable lz4 and seccomp for systemd
 PACKAGECONFIG:append = "lz4 seccomp coredump elfutils"
 PACKAGECONFIG:remove = "networkd"
+
+do_install:append() {
+    # We use system-update.target to re-partition the disk on first boot,
+    # meaning we do not have all partitions available on the very first boot
+    # and need to keep the mountpoints where they should be mounted clean.
+    #
+    # This breaks a dependency chain that would result in a /srv/journal
+    # directory being created in the rootfs's /srv:
+    # system-update.target -> sysinit.target -> systemd-journal-flush.service
+    # -> var-log-journal.mount
+    mv ${D}${systemd_system_unitdir}/sysinit.target.wants/systemd-journal-flush.service	\
+       ${D}${systemd_system_unitdir}/multi-user.target.wants/
+}

--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -47,6 +47,12 @@ function migrate () {
 case "$1" in
 	slot-post-install)
 		enable_certificates
+
+		# The repartitioning triggered by the existence of
+		# /system-update is only required on the first boot after
+		# installing from an eMMC image.
+		rm -f "${RAUC_SLOT_MOUNT_POINT}/system-update"
+
 		migrate /etc/machine-id
 		migrate /etc/labgrid/environment
 		migrate /etc/labgrid/userconfig.yaml

--- a/meta-lxatac-software/recipes-daemons/atftp/atftp_%.bbappend
+++ b/meta-lxatac-software/recipes-daemons/atftp/atftp_%.bbappend
@@ -1,14 +1,16 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://atftp-tmpfiles.conf"
+SRC_URI += "file://create-dir.conf"
 
 # On the TAC /srv is a separate partition, which does however fail to
 # mount if the tftp directory already exists.
-# Instead make sure that /srv/tftp is generated at runtime by tmpfiles.d.
+# Instead make sure that /srv/tftp is generated at runtime by an ExecStartPre
+# in the service.
 do_install:append() {
     rmdir ${D}/srv/tftp ${D}/srv
 
-    install -D -m 0644 ${WORKDIR}/atftp-tmpfiles.conf ${D}${libdir}/tmpfiles.d/atftp.conf
+    install -D -m 0644 ${S}/../create-dir.conf \
+        ${D}${systemd_unitdir}/system/atftpd.service.d/create-dir.conf
 }
 
-FILES:${PN}d += "${libdir}/tmpfiles.d"
+FILES:${PN}d += "${systemd_unitdir}/system/atftpd.service.d"

--- a/meta-lxatac-software/recipes-daemons/atftp/files/atftp-tmpfiles.conf
+++ b/meta-lxatac-software/recipes-daemons/atftp/files/atftp-tmpfiles.conf
@@ -1,2 +1,0 @@
-# Path			Mode	UID	GID	Age Argument
-d /srv/tftp		1775	root	root	2d

--- a/meta-lxatac-software/recipes-daemons/atftp/files/create-dir.conf
+++ b/meta-lxatac-software/recipes-daemons/atftp/files/create-dir.conf
@@ -1,0 +1,11 @@
+# The systemd-tmpfiles-setup service is part of the sysinit.target,
+# which is run even before system-update.target, which we use on first
+# boot of a new image install to re-partition the eMMC.
+# We can not clutter /srv/ on this very first boot, so create the directory
+# as part of the service startup instead.
+
+[Unit]
+RequiresMountsFor=/srv
+
+[Service]
+ExecStartPre=mkdir -p /srv/tftp

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -2,6 +2,7 @@
 Description=Labgrid exporter
 After=network-online.target
 Wants=network-online.target
+RequiresMountsFor=/var/cache/labgrid
 
 [Service]
 Type=simple

--- a/meta-lxatac-software/recipes-rust/tacd/files/tacd.service
+++ b/meta-lxatac-software/recipes-rust/tacd/files/tacd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=LXA TAC Daemon
 Before=collectd.service
+RequiresMountsFor=/srv/tacd
 
 [Service]
 Type=notify


### PR DESCRIPTION
This fixes an issue that comes up every time a LXA TAC is freshly deployed with a new eMMC image via fastboot (e.g. not via RAUC update).

On the first boot after deploying an image the partition that should be mounted to `/srv` is not yet generated by `systemd-repart`.
`systemd-repart` does however run later in the boot process than `systemd-gpt-auto-generator`.
As a consequence of that there is no `srv.mount` on first boot and every unit that writes to `/srv`  just clutters the rootfs with directories and files. This will result in issues on every subsequent boot as `systemd-gpt-auto-generator` does not generate mount units for directories that are not empty.

Currently we have to manually clear the cluttered `/srv/` after flashing a new image. This is not acceptable.

Instead use the `system-update.target` to perform just the repartioning on first boot and make sure no units that clutter `/srv` are pulled in by  `system-update.target` (e.g. via `sysinit.target`).

This PR supersedes #24 which tried to solve the same issue in a less fancy way. That PR can thus be closed.