### PR TITLE
meta-lxatac-software: tacd: update to tacd with http directory listings

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "88d20f145ea27d0af39cd412a6f51b2f514ca254"
+SRCREV = "f62197488e51f7717cd93688565fed740c764ff2"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"
@@ -136,6 +136,7 @@ SRC_URI += " \
     crate://crates.io/hkdf/0.10.0 \
     crate://crates.io/hmac/0.10.1 \
     crate://crates.io/hmac/0.8.1 \
+    crate://crates.io/html-escape/0.2.13 \
     crate://crates.io/http-client/6.5.3 \
     crate://crates.io/http-types/2.12.0 \
     crate://crates.io/http/0.2.9 \
@@ -285,6 +286,7 @@ SRC_URI += " \
     crate://crates.io/url/2.3.1 \
     crate://crates.io/utf-8/0.7.6 \
     crate://crates.io/utf8-cstr/0.1.6 \
+    crate://crates.io/utf8-width/0.1.6 \
     crate://crates.io/value-bag/1.0.0-alpha.9 \
     crate://crates.io/version_check/0.9.4 \
     crate://crates.io/waker-fn/1.1.0 \

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -1,10 +1,10 @@
 SRC_URI = " \
-    git://git@github.com/linux-automation/tacd.git;protocol=https;branch=main \
+    git://github.com/linux-automation/tacd.git;protocol=https;branch=main \
     npmsw://${THISDIR}/${BPN}/npm-shrinkwrap.json \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "88d20f145ea27d0af39cd412a6f51b2f514ca254"
+SRCREV = "f62197488e51f7717cd93688565fed740c764ff2"
 
 S = "${WORKDIR}/git/web"
 
@@ -19,6 +19,11 @@ WEBUI_INSTALL_DIR="${NPM_BUILD}/lib/node_modules/tacd-web"
 npm_run_build () {
     cd "${WEBUI_INSTALL_DIR}"
     npm run build
+
+    # Provide compressed variants of all files worth compressing
+    find build/ -type f \
+        \( -name "*.html" -or -name "*.css" -or -name "*.js" -or -name "*.svg" \) \
+        -exec gzip -fk9 {} \;
 }
 
 do_compile:append() {


### PR DESCRIPTION
… and compressed file serving and caching headers.

This integrates linux-automation/tacd#23 into `meta-lxatac` and adds a step to the `tacd-webinterface_git.bb` recipe to pre-compress the files that make up the web interface.

Related Pull Requests
---------------

This PR depends on the following other PRs which should be merged first:

- [x] The `tacd` PR this feature is built on linux-automation/tacd#23.
- [x] The `meta-lxatac` PR that adds Gen 2 support as the new `tacd` uses the larger display #33.
- [x] The `meta-lxatac` PR that adds RAUC update polling #38 (as the new `tacd` includes that feature).