### PR TITLE
Add iio in-kernel buffering support for the powerboard ADC

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/defconfig
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.4.0-20230627-1 Kernel Configuration
+# Linux/arm 6.4.0-20230627-2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-oe-linux-gnueabi-gcc (GCC) 12.2.0"
 CONFIG_CC_IS_GCC=y

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0401-iio-adc-add-buffering-support-to-the-TI-LMP92064-ADC.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0401-iio-adc-add-buffering-support-to-the-TI-LMP92064-ADC.patch
@@ -1,0 +1,121 @@
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Thu, 8 Jun 2023 10:21:55 +0200
+Subject: [PATCH] iio: adc: add buffering support to the TI LMP92064 ADC driver
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enable buffered reading of samples from the LMP92064 ADC.
+The main benefit of this change is being able to read out current and
+voltage measurements in a single transfer, allowing instantaneous power
+measurements.
+
+Reads into the buffer can be triggered by any software triggers, e.g.
+the iio-trig-hrtimer:
+
+    $ mkdir /sys/kernel/config/iio/triggers/hrtimer/my-trigger
+    $ cat /sys/bus/iio/devices/iio\:device3/name
+    lmp92064
+    $ iio_readdev -t my-trigger -b 16 iio:device3 | hexdump
+    WARNING: High-speed mode not enabled
+    0000000 0000 0176 0101 0001 5507 abd5 7645 1768
+    0000010 0000 016d 0101 0001 ee1e ac6b 7645 1768
+    ...
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ drivers/iio/adc/ti-lmp92064.c | 50 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 50 insertions(+)
+
+diff --git a/drivers/iio/adc/ti-lmp92064.c b/drivers/iio/adc/ti-lmp92064.c
+index c30ed824924f..a4e64ee8a7b5 100644
+--- a/drivers/iio/adc/ti-lmp92064.c
++++ b/drivers/iio/adc/ti-lmp92064.c
+@@ -16,7 +16,10 @@
+ #include <linux/spi/spi.h>
+ 
+ #include <linux/iio/iio.h>
++#include <linux/iio/buffer.h>
+ #include <linux/iio/driver.h>
++#include <linux/iio/triggered_buffer.h>
++#include <linux/iio/trigger_consumer.h>
+ 
+ #define TI_LMP92064_REG_CONFIG_A 0x0000
+ #define TI_LMP92064_REG_CONFIG_B 0x0001
+@@ -91,6 +94,12 @@ static const struct iio_chan_spec lmp92064_adc_channels[] = {
+ 		.address = TI_LMP92064_CHAN_INC,
+ 		.info_mask_separate =
+ 			BIT(IIO_CHAN_INFO_RAW) | BIT(IIO_CHAN_INFO_SCALE),
++		.scan_index = TI_LMP92064_CHAN_INC,
++		.scan_type = {
++			.sign = 'u',
++			.realbits = 12,
++			.storagebits = 16,
++		},
+ 		.datasheet_name = "INC",
+ 	},
+ 	{
+@@ -98,8 +107,20 @@ static const struct iio_chan_spec lmp92064_adc_channels[] = {
+ 		.address = TI_LMP92064_CHAN_INV,
+ 		.info_mask_separate =
+ 			BIT(IIO_CHAN_INFO_RAW) | BIT(IIO_CHAN_INFO_SCALE),
++		.scan_index = TI_LMP92064_CHAN_INV,
++		.scan_type = {
++			.sign = 'u',
++			.realbits = 12,
++			.storagebits = 16,
++		},
+ 		.datasheet_name = "INV",
+ 	},
++	IIO_CHAN_SOFT_TIMESTAMP(2),
++};
++
++static const unsigned long lmp92064_scan_masks[] = {
++	BIT(TI_LMP92064_CHAN_INC) | BIT(TI_LMP92064_CHAN_INV),
++	0
+ };
+ 
+ static int lmp92064_read_meas(struct lmp92064_adc_priv *priv, u16 *res)
+@@ -171,6 +192,29 @@ static int lmp92064_read_raw(struct iio_dev *indio_dev,
+ 	}
+ }
+ 
++static irqreturn_t lmp92064_trigger_handler(int irq, void *p)
++{
++	struct iio_poll_func *pf = p;
++	struct iio_dev *indio_dev = pf->indio_dev;
++	struct lmp92064_adc_priv *priv = iio_priv(indio_dev);
++	struct {
++		u16 values[2];
++		int64_t timestamp;
++	} data;
++	int ret;
++
++	ret = lmp92064_read_meas(priv, data.values);
++	if (ret >= 0) {
++		/* Only push values if the read succeeded */
++		iio_push_to_buffers_with_timestamp(indio_dev, &data,
++						   iio_get_time_ns(indio_dev));
++	}
++
++	iio_trigger_notify_done(indio_dev->trig);
++
++	return IRQ_HANDLED;
++}
++
+ static int lmp92064_reset(struct lmp92064_adc_priv *priv,
+ 			  struct gpio_desc *gpio_reset)
+ {
+@@ -301,6 +345,12 @@ static int lmp92064_adc_probe(struct spi_device *spi)
+ 	indio_dev->channels = lmp92064_adc_channels;
+ 	indio_dev->num_channels = ARRAY_SIZE(lmp92064_adc_channels);
+ 	indio_dev->info = &lmp92064_adc_info;
++	indio_dev->available_scan_masks = lmp92064_scan_masks;
++
++	ret = devm_iio_triggered_buffer_setup(dev, indio_dev, NULL,
++					      lmp92064_trigger_handler, NULL);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to setup buffered read\n");
+ 
+ 	return devm_iio_device_register(dev, indio_dev);
+ }

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0501-Release-6.4-customers-lxa-lxatac-20230627-2.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0501-Release-6.4-customers-lxa-lxatac-20230627-2.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Tue, 27 Jun 2023 10:57:45 +0200
-Subject: [PATCH] Release 6.4/customers/lxa/lxatac/20230627-1
+Date: Tue, 27 Jun 2023 11:05:56 +0200
+Subject: [PATCH] Release 6.4/customers/lxa/lxatac/20230627-2
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index e51e4d9174ab..48a3313c9438 100644
+index e51e4d9174ab..1274dfb01fa5 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index e51e4d9174ab..48a3313c9438 100644
  PATCHLEVEL = 4
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20230627-1
++EXTRAVERSION =-20230627-2
  NAME = Hurr durr I'ma ninja sloth
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
@@ -1,6 +1,6 @@
 # umpf-base: v6.4
 # umpf-name: 6.4/customers/lxa/lxatac
-# umpf-version: 6.4/customers/lxa/lxatac/20230627-1
+# umpf-version: 6.4/customers/lxa/lxatac/20230627-2
 # umpf-topic: v6.4/customers/lxa/lxatac
 # umpf-hashinfo: 927820f53568ba95758663f0de98d7cbd7d9b911
 # umpf-topic-range: 6995e2de6891c724bfeb2db33d7b87775f913ad1..678243c254e6835b25e29f8ccf8a52d6b67174b1
@@ -33,9 +33,15 @@ SRC_URI += "\
 SRC_URI += "\
   file://patches/0301-backlight-pwm_bl-Avoid-backlight-flicker-applying-in.patch \
   "
-# umpf-release: 6.4/customers/lxa/lxatac/20230627-1
-# umpf-topic-range: 2defd6502d2b3f5251749f9f621e69f5b2bca5e7..c47d8de008eda2fd9248482ee04d40f32ad0a85b
+# umpf-topic: v6.4/topic/lmp92064
+# umpf-hashinfo: 8a6b5ffc4c09287732c41b3f4106097d5aea6c68
+# umpf-topic-range: 2defd6502d2b3f5251749f9f621e69f5b2bca5e7..56460c1cc9c689db761ab3a7c6cbfa8c1755c65f
 SRC_URI += "\
-  file://patches/0401-Release-6.4-customers-lxa-lxatac-20230627-1.patch \
+  file://patches/0401-iio-adc-add-buffering-support-to-the-TI-LMP92064-ADC.patch \
+  "
+# umpf-release: 6.4/customers/lxa/lxatac/20230627-2
+# umpf-topic-range: 56460c1cc9c689db761ab3a7c6cbfa8c1755c65f..87efd2c0c677d688d00589681b651a2f586a96fb
+SRC_URI += "\
+  file://patches/0501-Release-6.4-customers-lxa-lxatac-20230627-2.patch \
   "
 # umpf-end

--- a/meta-lxatac-bsp/recipes-support/libiio/libiio/0001-local-Fix-detection-of-scan-element-channels.patch
+++ b/meta-lxatac-bsp/recipes-support/libiio/libiio/0001-local-Fix-detection-of-scan-element-channels.patch
@@ -1,0 +1,35 @@
+From 77e840b94c5738783b5dcc93cf7cabaac5034737 Mon Sep 17 00:00:00 2001
+From: Paul Cercueil <paul@crapouillou.net>
+Date: Wed, 8 Sep 2021 09:35:03 +0100
+Subject: [PATCH] local: Fix detection of scan-element channels
+
+Previously, the detection of buffer-capable channels would fail when the
+channel had attributes outside the scan_elements/ folder, as the channel
+would be correctly marked as buffer-capable when the first attribute
+was found, but then overriden as non-buffer-capable as soon as an
+attribute outside the scan_elements/ folder was found.
+
+It went unnoticed until now, most likely because there is generally
+either scan-elements attributes or non-scan-elements attributes, and
+rarely both.
+
+Fixes #740.
+
+Signed-off-by: Paul Cercueil <paul@crapouillou.net>
+---
+ local.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/local.c b/local.c
+index bbb62fe..e909520 100644
+--- a/local.c
++++ b/local.c
+@@ -1476,7 +1476,7 @@ static int add_channel(struct iio_device *dev, const char *name,
+ 			free(channel_id);
+ 			ret = add_attr_to_channel(chn, name, path,
+ 					dir_is_scan_elements);
+-			chn->is_scan_element = dir_is_scan_elements && !ret;
++			chn->is_scan_element |= dir_is_scan_elements && !ret;
+ 			return ret;
+ 		}
+ 	}

--- a/meta-lxatac-bsp/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-lxatac-bsp/recipes-support/libiio/libiio_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-local-Fix-detection-of-scan-element-channels.patch"
+

--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "d398d608bfcf472e87f144af7fb4c3948a46f058"
+SRCREV = "77944468f9827167ef9e6bc4c628506c77a580b7"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -4,7 +4,7 @@ SRC_URI = " \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "d398d608bfcf472e87f144af7fb4c3948a46f058"
+SRCREV = "77944468f9827167ef9e6bc4c628506c77a580b7"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This PR adds tacd and linux kernel support for industrial i/o (iio) buffering of the ADC on the LXA TAC powerboard.
The ADC is attached via SPI and always samples on its own in the background.

Related Pull Requests
------------

This PR is based on some other PRs that should be kept in mind:

- [x] The `tacd` pull request that adds this feature linux-automation/tacd#27
- [x] The `meta-lxatac` pull request that last updated the `tacd` #46
- [x] The `meta-lxatac` pull request that updates the kernel to 6.4 (which this PR is based on) #45 
- [x] ~~A future `libiio` pull request that includes the workaround that is required to enable the iio buffer.~~ This issue was already fixed in analogdevicesinc/libiio#744. I've backported the patch for now. The patch can be dropped on the next `libiio` update (which is already in `meta-oe` master).