### PR TITLE
labgrid-exporter: add digital output OUT_0/OUT_1 support

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -27,16 +27,17 @@ serial:
     port: /dev/ttySTM1
     speed: {{serial.baud}}
 
-## FIXME: These should be accessed via the REST API at
-## - /v1/output/out_0/asserted
-## - /v1/output/out_1/asserted
-## gpio0:
-##   SysfsGPIO:
-##     index: 115
-##
-## gpio1:
-##   SysfsGPIO:
-##     index: 114
+out_0:
+  HttpDigitalOutput:
+    url: 'http://{{ hostname }}/v1/output/out_0/asserted'
+    body_asserted: "true"
+    body_deasserted: "false"
+
+out_1:
+  HttpDigitalOutput:
+    url: 'http://{{ hostname }}/v1/output/out_1/asserted'
+    body_asserted: "true"
+    body_deasserted: "false"
 
 dut_power:
   NetworkPowerPort:

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
@@ -1,9 +1,14 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/python3-labgrid:" 
 
+SRC_URI:remove = "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
+
 SRC_URI += " \
+    git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master \
     file://userconfig.yaml \
     file://labgrid.conf \
 "
+
+SRCREV = "3e1c0df0a3503d6f22e63a50ae45945ed12b69f8"
 
 do_install:append() {
     # The userconfig.yaml is migrated via rauc hook between installs.


### PR DESCRIPTION
~~Backport~~ Use the `HttpDigitalOutputDriver` from labgrid-project/labgrid#1224 and add configuration to use it.

Related Pull Requests
---------------

This PR uses a feature that is not yet merged into the upstream project:

- [x] The `labgrid` PR that is used in this PR labgrid-project/labgrid#1224. We should likely wait for some feedback there before merging this PR here.
