### PR TITLE
meta-lxatac-software: tac-gadget: Multi function USB gadget

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0109-ARM-dts-stm32-lxa-tac-adjust-USB-gadget-fifo-sizes-f.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0109-ARM-dts-stm32-lxa-tac-adjust-USB-gadget-fifo-sizes-f.patch
@@ -1,0 +1,31 @@
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Wed, 28 Jun 2023 13:26:48 +0200
+Subject: [PATCH] ARM: dts: stm32: lxa-tac: adjust USB gadget fifo sizes for
+ multi function
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This allows e.g. providing the ethernet and mass storage functions on the
+peripheral port at the same time.
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ arch/arm/boot/dts/stm32mp15xc-lxa-tac.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/boot/dts/stm32mp15xc-lxa-tac.dtsi b/arch/arm/boot/dts/stm32mp15xc-lxa-tac.dtsi
+index 184b8bb4ebbf..1bb193440415 100644
+--- a/arch/arm/boot/dts/stm32mp15xc-lxa-tac.dtsi
++++ b/arch/arm/boot/dts/stm32mp15xc-lxa-tac.dtsi
+@@ -580,6 +580,10 @@ &usbotg_hs {
+ 	vusb_d-supply = <&vdd_usb>;
+ 	vusb_a-supply = <&reg18>;
+ 
++	g-rx-fifo-size = <512>;
++	g-np-tx-fifo-size = <32>;
++	g-tx-fifo-size = <128 128 64 16 16 16 16 16>;
++
+ 	dr_mode = "peripheral";
+ 
+ 	status = "okay";

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0501-Release-6.4-customers-lxa-lxatac-20230628-1.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0501-Release-6.4-customers-lxa-lxatac-20230628-1.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Tue, 27 Jun 2023 11:05:56 +0200
-Subject: [PATCH] Release 6.4/customers/lxa/lxatac/20230627-2
+Date: Wed, 28 Jun 2023 13:30:43 +0200
+Subject: [PATCH] Release 6.4/customers/lxa/lxatac/20230628-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index e51e4d9174ab..1274dfb01fa5 100644
+index e51e4d9174ab..5ea8efade357 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index e51e4d9174ab..1274dfb01fa5 100644
  PATCHLEVEL = 4
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20230627-2
++EXTRAVERSION =-20230628-1
  NAME = Hurr durr I'ma ninja sloth
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
@@ -1,6 +1,6 @@
 # umpf-base: v6.4
 # umpf-name: 6.4/customers/lxa/lxatac
-# umpf-version: 6.4/customers/lxa/lxatac/20230627-2
+# umpf-version: 6.4/customers/lxa/lxatac/20230628-1
 # umpf-topic: v6.4/customers/lxa/lxatac
 # umpf-hashinfo: 927820f53568ba95758663f0de98d7cbd7d9b911
 # umpf-topic-range: 6995e2de6891c724bfeb2db33d7b87775f913ad1..678243c254e6835b25e29f8ccf8a52d6b67174b1
@@ -9,8 +9,8 @@ SRC_URI += "\
   file://patches/0002-leds-trigger-tty-Use-led_set_brightness_nosleep-from.patch \
   "
 # umpf-topic: v6.4/topic/lxa-tac-dts-mainlining
-# umpf-hashinfo: 43263feecafa4a0443b19179931545b2a055427f
-# umpf-topic-range: 678243c254e6835b25e29f8ccf8a52d6b67174b1..a42d782080c1185c058d7957c3270cf81a07927a
+# umpf-hashinfo: bd4961142956aad55805e3cb3e6f4f792ce208ff
+# umpf-topic-range: 678243c254e6835b25e29f8ccf8a52d6b67174b1..bd79efc530ede8973a3586b016271eac7783e9b8
 SRC_URI += "\
   file://patches/0101-dt-bindings-vendor-prefixes-Add-prefix-for-ShineWorl.patch \
   file://patches/0102-dt-bindings-display-panel-mipi-dbi-spi-add-shineworl.patch \
@@ -20,28 +20,29 @@ SRC_URI += "\
   file://patches/0106-ARM-dts-stm32-Add-pinmux-groups-for-Linux-Automation.patch \
   file://patches/0107-dt-bindings-arm-stm32-Add-compatible-string-for-Linu.patch \
   file://patches/0108-ARM-dts-stm32-lxa-tac-add-Linux-Automation-GmbH-TAC.patch \
+  file://patches/0109-ARM-dts-stm32-lxa-tac-adjust-USB-gadget-fifo-sizes-f.patch \
   "
 # umpf-topic: v6.4/topic/pwm-stm32
 # umpf-hashinfo: 8b37f8455f4ff559c4ab91dd240329fe68ca606e
-# umpf-topic-range: a42d782080c1185c058d7957c3270cf81a07927a..0e7415245e0ccca6b31a1fd6aaf3a243d5993843
+# umpf-topic-range: bd79efc530ede8973a3586b016271eac7783e9b8..1f344a16e141d133734fc0d62c981d2c643dfb9a
 SRC_URI += "\
   file://patches/0201-pwm-stm32-Implement-.get_state.patch \
   "
 # umpf-topic: v6.4/topic/pwm-backlight
 # umpf-hashinfo: f5aa96f6c59d482b4d67776b4c79746b5567b92a
-# umpf-topic-range: 0e7415245e0ccca6b31a1fd6aaf3a243d5993843..2defd6502d2b3f5251749f9f621e69f5b2bca5e7
+# umpf-topic-range: 1f344a16e141d133734fc0d62c981d2c643dfb9a..7af7f4e3209bb6a4f2310ea11904a7a77bde3e8d
 SRC_URI += "\
   file://patches/0301-backlight-pwm_bl-Avoid-backlight-flicker-applying-in.patch \
   "
 # umpf-topic: v6.4/topic/lmp92064
 # umpf-hashinfo: 8a6b5ffc4c09287732c41b3f4106097d5aea6c68
-# umpf-topic-range: 2defd6502d2b3f5251749f9f621e69f5b2bca5e7..56460c1cc9c689db761ab3a7c6cbfa8c1755c65f
+# umpf-topic-range: 7af7f4e3209bb6a4f2310ea11904a7a77bde3e8d..a132785e7274e184caa36be02592ab239a5f83d5
 SRC_URI += "\
   file://patches/0401-iio-adc-add-buffering-support-to-the-TI-LMP92064-ADC.patch \
   "
-# umpf-release: 6.4/customers/lxa/lxatac/20230627-2
-# umpf-topic-range: 56460c1cc9c689db761ab3a7c6cbfa8c1755c65f..87efd2c0c677d688d00589681b651a2f586a96fb
+# umpf-release: 6.4/customers/lxa/lxatac/20230628-1
+# umpf-topic-range: a132785e7274e184caa36be02592ab239a5f83d5..dbeb021b81e1c1959fb3aaea69abcf3e0c9bcfc0
 SRC_URI += "\
-  file://patches/0501-Release-6.4-customers-lxa-lxatac-20230627-2.patch \
+  file://patches/0501-Release-6.4-customers-lxa-lxatac-20230628-1.patch \
   "
 # umpf-end

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-audio.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-audio.sh
@@ -5,10 +5,14 @@ set -e -u -o pipefail
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-audio
-FUNCTION="uac2.usb0"
 
 clear_gadget
 setup_gadget
+
+# Set up audio
+mkdir $DEVDIR/functions/uac2.usb0
+ln -s $DEVDIR/functions/uac2.usb0 $DEVDIR/configs/c.1
+
 start_gadget
 
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-audio.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-audio.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e -u -o pipefail
+
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-audio
@@ -8,4 +10,5 @@ FUNCTION="uac2.usb0"
 clear_gadget
 setup_gadget
 start_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 MAINDIR=/sys/kernel/config/usb_gadget
 
 # Read factory data that was prepared by

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
@@ -35,10 +35,7 @@ clear_gadget () {
             [ -d $str ] && rmdir $str
         done
         rmdir $MAINDIR/*
-        if [[ ! $DEVDIR || ! $FUNCTION ]]; then
-            exit 0
-        fi
-    elif [[ -n $DEVDIR && -n $FUNCTION ]]; then
+    elif [ -n $DEVDIR ]; then
         modprobe libcomposite
     else
         echo "Nothing to do here."

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-common.sh
@@ -57,11 +57,8 @@ setup_gadget () {
     mkdir $DEVDIR/configs/c.1
     mkdir $DEVDIR/configs/c.1/strings/0x409
     echo Normal > $DEVDIR/configs/c.1/strings/0x409/configuration
-
-    mkdir $DEVDIR/functions/$FUNCTION
 }
 
 start_gadget () {
-    ln -s $DEVDIR/functions/$FUNCTION $DEVDIR/configs/c.1
     echo $UDC_ADDR > $DEVDIR/UDC
 }

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-serial.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-serial.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+source /usr/share/gadget/gadget-common
+
+DEVDIR=$MAINDIR/gadget-ethernet-serial
+
+clear_gadget
+setup_gadget
+
+# Set up ethernet
+mkdir $DEVDIR/functions/ecm.usb0
+echo $HOST_MAC > $DEVDIR/functions/ecm.usb0/host_addr
+echo $DEV_MAC > $DEVDIR/functions/ecm.usb0/dev_addr
+ln -s $DEVDIR/functions/ecm.usb0 $DEVDIR/configs/c.1
+
+# Set up serial
+mkdir $DEVDIR/functions/acm.usb0
+ln -s $DEVDIR/functions/acm.usb0 $DEVDIR/configs/c.1
+
+start_gadget
+exit 0
+

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-storage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+STORAGE=${1:-}
+if [ -z $STORAGE ]; then
+    echo "ERROR: No medium given. Start again with image location attached to command."
+    exit 1
+fi
+
+source /usr/share/gadget/gadget-common
+
+DEVDIR=$MAINDIR/gadget-ethernet-storage
+
+clear_gadget
+setup_gadget
+
+# Set up ethernet
+mkdir $DEVDIR/functions/ecm.usb0
+echo $HOST_MAC > $DEVDIR/functions/ecm.usb0/host_addr
+echo $DEV_MAC > $DEVDIR/functions/ecm.usb0/dev_addr
+ln -s $DEVDIR/functions/ecm.usb0 $DEVDIR/configs/c.1
+
+# Set up storage
+mkdir $DEVDIR/functions/mass_storage.usb0
+echo $STORAGE > $DEVDIR/functions/mass_storage.usb0/lun.0/file
+ln -s $DEVDIR/functions/mass_storage.usb0 $DEVDIR/configs/c.1
+
+start_gadget
+exit 0
+

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet.sh
@@ -5,12 +5,16 @@ set -e -u -o pipefail
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-ethernet
-FUNCTION="ecm.usb0"
 
 clear_gadget
 setup_gadget
-echo $HOST_MAC > $DEVDIR/functions/$FUNCTION/host_addr
-echo $DEV_MAC > $DEVDIR/functions/$FUNCTION/dev_addr
+
+# Set up ethernet
+mkdir $DEVDIR/functions/ecm.usb0
+echo $HOST_MAC > $DEVDIR/functions/ecm.usb0/host_addr
+echo $DEV_MAC > $DEVDIR/functions/ecm.usb0/dev_addr
+ln -s $DEVDIR/functions/ecm.usb0 $DEVDIR/configs/c.1
+
 start_gadget
 
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e -u -o pipefail
+
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-ethernet
@@ -10,4 +12,5 @@ setup_gadget
 echo $HOST_MAC > $DEVDIR/functions/$FUNCTION/host_addr
 echo $DEV_MAC > $DEVDIR/functions/$FUNCTION/dev_addr
 start_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid-storage.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+STORAGE=${1:-}
+if [ -z $STORAGE ]; then
+    echo "ERROR: No medium given. Start again with image location attached to command."
+    exit 1
+fi
+
+source /usr/share/gadget/gadget-common
+source /usr/share/gadget/gadget-reports
+
+DEVDIR=$MAINDIR/gadget-hid-storage
+
+clear_gadget
+setup_gadget
+
+# Set up mass storage
+mkdir $DEVDIR/functions/mass_storage.usb0
+echo $STORAGE > $DEVDIR/functions/mass_storage.usb0/lun.0/file
+ln -s $DEVDIR/functions/mass_storage.usb0 $DEVDIR/configs/c.1
+
+# Set up HID
+mkdir $DEVDIR/functions/hid.usb0
+echo 1 > $DEVDIR/functions/hid.usb0/protocol
+echo 1 > $DEVDIR/functions/hid.usb0/subclass
+echo 8 > $DEVDIR/functions/hid.usb0/report_length
+report_keyboard > $DEVDIR/functions/hid.usb0/report_desc
+ln -s $DEVDIR/functions/hid.usb0 $DEVDIR/configs/c.1
+
+start_gadget
+
+exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e -u -o pipefail
+
 source /usr/share/gadget/gadget-common
 source /usr/share/gadget/gadget-reports
 
@@ -14,4 +16,5 @@ echo 1 > $DEVDIR/functions/hid.usb0/subclass
 echo 8 > $DEVDIR/functions/hid.usb0/report_length
 report_keyboard > $DEVDIR/functions/hid.usb0/report_desc
 start_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-hid.sh
@@ -6,15 +6,19 @@ source /usr/share/gadget/gadget-common
 source /usr/share/gadget/gadget-reports
 
 DEVDIR=$MAINDIR/gadget-hid
-FUNCTION="hid.usb0"
 
 echo "Will export keyboard configuration."
 clear_gadget
 setup_gadget
+
+# Set up HID
+mkdir $DEVDIR/functions/hid.usb0
 echo 1 > $DEVDIR/functions/hid.usb0/protocol
 echo 1 > $DEVDIR/functions/hid.usb0/subclass
 echo 8 > $DEVDIR/functions/hid.usb0/report_length
 report_keyboard > $DEVDIR/functions/hid.usb0/report_desc
+ln -s $DEVDIR/functions/hid.usb0 $DEVDIR/configs/c.1
+
 start_gadget
 
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-remove.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-remove.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+
 set -e -o pipefail
+
 source /usr/share/gadget/gadget-common
 
 clear_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial-storage.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+STORAGE=${1:-}
+if [ -z $STORAGE ]; then
+    echo "ERROR: No medium given. Start again with image location attached to command."
+    exit 1
+fi
+
+source /usr/share/gadget/gadget-common
+
+DEVDIR=$MAINDIR/gadget-serial-storage
+
+clear_gadget
+setup_gadget
+
+# Set up mass storage
+mkdir $DEVDIR/functions/mass_storage.usb0
+echo $STORAGE > $DEVDIR/functions/mass_storage.usb0/lun.0/file
+ln -s $DEVDIR/functions/mass_storage.usb0 $DEVDIR/configs/c.1
+
+# Set up serial
+mkdir $DEVDIR/functions/acm.usb0
+ln -s $DEVDIR/functions/acm.usb0 $DEVDIR/configs/c.1
+
+start_gadget
+
+exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial.sh
@@ -5,10 +5,14 @@ set -e -u -o pipefail
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-serial
-FUNCTION="acm.usb0"
 
 clear_gadget
 setup_gadget
+
+# Set up serial
+mkdir $DEVDIR/functions/acm.usb0
+ln -s $DEVDIR/functions/acm.usb0 $DEVDIR/configs/c.1
+
 start_gadget
 
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-serial.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e -u -o pipefail
+
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-serial
@@ -8,4 +10,5 @@ FUNCTION="acm.usb0"
 clear_gadget
 setup_gadget
 start_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
@@ -3,12 +3,12 @@
 set -e -u -o pipefail
 
 STORAGE=${1:-}
-if [ $STORAGE ]; then
-    source /usr/share/gadget/gadget-common
-else
+if [ -z $STORAGE ]; then
     echo "ERROR: No medium given. Start again with image location attached to command."
     exit 1
 fi
+
+source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-storage
 FUNCTION="mass_storage.usb0"

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e -u -o pipefail
+
 STORAGE=${1:-}
 if [ $STORAGE ]; then
     source /usr/share/gadget/gadget-common
@@ -15,4 +17,5 @@ clear_gadget
 setup_gadget
 echo $STORAGE > $DEVDIR/functions/mass_storage.usb0/lun.0/file
 start_gadget
+
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-storage.sh
@@ -11,11 +11,15 @@ fi
 source /usr/share/gadget/gadget-common
 
 DEVDIR=$MAINDIR/gadget-storage
-FUNCTION="mass_storage.usb0"
 
 clear_gadget
 setup_gadget
+
+# Set up storage
+mkdir $DEVDIR/functions/mass_storage.usb0
 echo $STORAGE > $DEVDIR/functions/mass_storage.usb0/lun.0/file
+ln -s $DEVDIR/functions/mass_storage.usb0 $DEVDIR/configs/c.1
+
 start_gadget
 
 exit 0

--- a/meta-lxatac-software/recipes-devtools/tac-gadget/tac-gadget.bb
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/tac-gadget.bb
@@ -12,21 +12,30 @@ RDEPENDS:${PN} = " \
 SRC_URI = " \
     file://gadget-audio.sh \
     file://gadget-common.sh \
+    file://gadget-ethernet-serial.sh \
+    file://gadget-ethernet-storage.sh \
     file://gadget-ethernet.sh \
+    file://gadget-hid-storage.sh \
     file://gadget-hid.sh \
     file://gadget-remove.sh \
+    file://gadget-reports.sh \
+    file://gadget-serial-storage.sh \
     file://gadget-serial.sh \
     file://gadget-storage.sh \
-    file://gadget-reports.sh \
 "
 
 do_install () {
     install -D -m0644 ${WORKDIR}/gadget-common.sh ${D}${datadir}/gadget/gadget-common
     install -D -m0644 ${WORKDIR}/gadget-reports.sh ${D}${datadir}/gadget/gadget-reports
+
     install -D -m0755 ${WORKDIR}/gadget-audio.sh ${D}${bindir}/tac-gadget-audio
+    install -D -m0755 ${WORKDIR}/gadget-ethernet-serial.sh ${D}${bindir}/tac-gadget-ethernet-serial
+    install -D -m0755 ${WORKDIR}/gadget-ethernet-storage.sh ${D}${bindir}/tac-gadget-ethernet-storage
     install -D -m0755 ${WORKDIR}/gadget-ethernet.sh ${D}${bindir}/tac-gadget-ethernet
+    install -D -m0755 ${WORKDIR}/gadget-hid-storage.sh ${D}${bindir}/tac-gadget-hid-storage
     install -D -m0755 ${WORKDIR}/gadget-hid.sh ${D}${bindir}/tac-gadget-hid
     install -D -m0755 ${WORKDIR}/gadget-remove.sh ${D}${bindir}/tac-gadget-remove
+    install -D -m0755 ${WORKDIR}/gadget-serial-storage.sh ${D}${bindir}/tac-gadget-serial-storage
     install -D -m0755 ${WORKDIR}/gadget-serial.sh ${D}${bindir}/tac-gadget-serial
     install -D -m0755 ${WORKDIR}/gadget-storage.sh ${D}${bindir}/tac-gadget-storage
 }


### PR DESCRIPTION
This PR adds a devicetree patch that enables using multiple USB gadget functions a the same time (see [this mail thread for why this is required][1]) and a set of scripts to set up such multi-function gadgets.

We are currently still limited to two functions at once by the FIFO configuration, as two functions (using the maximum message sizes currently configured in the drivers) is the maximum that can fit into the 4K SRAM of the dwc2 controller.

I've thus added the following two-function setup scripts that I could come up with a use case for:

  - `tac-gadget-ethernet-serial` (Ethernet + Serial)

    Could be useful to rescue a system with broken network support that is configured to open a console on `/dev/ttyACM0`.

  - `tac-gadget-ethernet-storage` (Ethernet + Mass Storage)

    Tested this by booting a Arch Linux install .iso on my laptop via USB and connecting it to the internet by adding the `usb0` interface on the TAC to the `tac-bridge`.

  - `tac-gadget-hid-storage` (HID + Mass Storage)

    Could be useful to boot x86 devices via USB by simulating the right keyboard presses.
    *"F12, down arrow, down arrow, enter"*.

  - `tac-gadget-serial-storage` (Serial + Mass Storage)

    Tested this by booting a Arch Linux install .iso on my laptop via USB and controlling it via the simulated serial port.

Related Pull Requests
------------

This PR is based on another PRs that should be kept in mind:

- [x] The `meta-lxatac` pull request that last touched the kernel patch stack: #47

[1]: https://lore.kernel.org/linux-arm-kernel/20230112112013.1086787-1-u.kleine-koenig@pengutronix.de/