### PR TITLE
 lxatac-core-image-base: ship imx-uuu for uploading U-Boot

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL:append = "\
     gstreamer1.0-plugins-good \
     htop \
     i2c-tools \
+    imx-uuu \
     iperf3 \
     iproute2 \
     iproute2-bash-completion \

--- a/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.21.bb
+++ b/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.21.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Universal Update Utility"
+DESCRIPTION = "Image deployment tool for i.MX chips"
+HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
+
+SRC_URI = "https://github.com/nxp-imx/mfgtools/releases/download/uuu_${PV}/uuu_source-${PV}.tar.gz"
+SRC_URI[sha256sum] = "600be50827b52df4dddf0c7d07da27b103a4576eb445890905c61780e3c36871"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=38ec0c18112e9a92cffc4951661e85a5"
+
+inherit cmake pkgconfig
+
+S = "${WORKDIR}/uuu-${PV}"
+
+DEPENDS = "libusb zlib bzip2 openssl"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
We already ship barebox-tools which contains imx-usb-loader for uploading barebox binaries to i.MX SoCs, so let's build and ship uuu as well for uploading U-Boot binaries.