### PR TITLE
linux-lxatac/tacd: drive powerboard GPIOs as open-drain

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0009-ARM-dts-stm32-lxa-tac-drive-powerboard-lines-as-open.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0009-ARM-dts-stm32-lxa-tac-drive-powerboard-lines-as-open.patch
@@ -1,0 +1,43 @@
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Thu, 17 Aug 2023 10:08:59 +0200
+Subject: [PATCH] ARM: dts: stm32: lxa-tac: drive powerboard lines as
+ open-drain
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This results in a slight improvement in EMI performance due to the lines
+no longer being driven by the somewhat noisy VDD_IO supply of the SoM.
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ arch/arm/boot/dts/st/stm32mp157c-lxa-tac-gen2.dts | 2 +-
+ arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boot/dts/st/stm32mp157c-lxa-tac-gen2.dts b/arch/arm/boot/dts/st/stm32mp157c-lxa-tac-gen2.dts
+index 8a34d15e9005..4cc177031661 100644
+--- a/arch/arm/boot/dts/st/stm32mp157c-lxa-tac-gen2.dts
++++ b/arch/arm/boot/dts/st/stm32mp157c-lxa-tac-gen2.dts
+@@ -148,7 +148,7 @@ adc@0 {
+ 		compatible = "ti,lmp92064";
+ 		reg = <0>;
+ 
+-		reset-gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&gpioa 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 		shunt-resistor-micro-ohms = <15000>;
+ 		spi-max-frequency = <5000000>;
+ 		vdd-supply = <&reg_pb_3v3>;
+diff --git a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+index 1bb193440415..e5dad090551c 100644
+--- a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
++++ b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+@@ -409,7 +409,7 @@ &sdmmc2 {
+ &spi2 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi2_pins_c>;
+-	cs-gpios = <&gpiof 12 GPIO_ACTIVE_LOW>;
++	cs-gpios = <&gpiof 12 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
+ 	status = "okay";
+ };
+ 

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0401-Release-6.5-customers-lxa-lxatac-20230901-2.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0401-Release-6.5-customers-lxa-lxatac-20230901-2.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Fri, 1 Sep 2023 08:47:44 +0200
-Subject: [PATCH] Release 6.5/customers/lxa/lxatac/20230901-1
+Date: Fri, 1 Sep 2023 08:51:51 +0200
+Subject: [PATCH] Release 6.5/customers/lxa/lxatac/20230901-2
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 2fdd8b40b7e0..19f728600203 100644
+index 2fdd8b40b7e0..d1ea88678301 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 2fdd8b40b7e0..19f728600203 100644
  PATCHLEVEL = 5
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20230901-1
++EXTRAVERSION =-20230901-2
  NAME = Hurr durr I'ma ninja sloth
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
@@ -1,9 +1,9 @@
 # umpf-base: v6.5
 # umpf-name: 6.5/customers/lxa/lxatac
-# umpf-version: 6.5/customers/lxa/lxatac/20230901-1
+# umpf-version: 6.5/customers/lxa/lxatac/20230901-2
 # umpf-topic: v6.5/customers/lxa/lxatac
-# umpf-hashinfo: 5749e67e0c2004dca628d140cb24009c7cdb51b1
-# umpf-topic-range: 2dde18cd1d8fac735875f2e4987f11817cc0bc2c..a13b48119b098c3886901cc46d01a8cd488f53ea
+# umpf-hashinfo: 3709235f8c53fc9b6f027de3390dfc59755a59aa
+# umpf-topic-range: 2dde18cd1d8fac735875f2e4987f11817cc0bc2c..3cb5f5381dd8aeff16f98be5e4084040d919429d
 SRC_URI += "\
   file://patches/0001-dt-bindings-can-m_can-change-from-additional-to-unev.patch \
   file://patches/0002-dt-bindings-net-dsa-microchip-add-interrupts-propert.patch \
@@ -13,10 +13,11 @@ SRC_URI += "\
   file://patches/0006-ARM-dts-stm32-lxa-tac-adjust-USB-gadget-fifo-sizes-f.patch \
   file://patches/0007-net-dsa-microchip-HACK-in-drive-strength-settings-to.patch \
   file://patches/0008-leds-trigger-tty-Use-led_set_brightness_nosleep-from.patch \
+  file://patches/0009-ARM-dts-stm32-lxa-tac-drive-powerboard-lines-as-open.patch \
   "
 # umpf-topic: v6.5/topic/pwm-stm32
 # umpf-hashinfo: 0a81cfa2fa0c23e9f0b7cb8fcac647af866b6b5b
-# umpf-topic-range: a13b48119b098c3886901cc46d01a8cd488f53ea..a037f83055cc0511dd0a939f5aea6abcd444f9fa
+# umpf-topic-range: 3cb5f5381dd8aeff16f98be5e4084040d919429d..17bbf2c7ec8a501b06316e26bf153b59b2a51a67
 SRC_URI += "\
   file://patches/0101-pwm-stm32-Replace-write_ccrx-with-regmap_write.patch \
   file://patches/0102-pwm-stm32-Make-ch-parameter-unsigned.patch \
@@ -25,19 +26,19 @@ SRC_URI += "\
   "
 # umpf-topic: v6.5/topic/pwm-backlight
 # umpf-hashinfo: 7f684487c94a882dd63183e8d8563c6ae90c983c
-# umpf-topic-range: a037f83055cc0511dd0a939f5aea6abcd444f9fa..d9ba11b8c2d4f94449041ab9d40278e5848b2259
+# umpf-topic-range: 17bbf2c7ec8a501b06316e26bf153b59b2a51a67..c0f576f113c2d9ea6050f2f35c7a2f7c716606d1
 SRC_URI += "\
   file://patches/0201-backlight-pwm_bl-Avoid-backlight-flicker-applying-in.patch \
   "
 # umpf-topic: v6.5/topic/lmp92064
 # umpf-hashinfo: 51bcd7180839086d74c7a74becccdc9e66597502
-# umpf-topic-range: d9ba11b8c2d4f94449041ab9d40278e5848b2259..1023956dbecbb04c6edcb1c38229034800a2b4e9
+# umpf-topic-range: c0f576f113c2d9ea6050f2f35c7a2f7c716606d1..5f3889a4a5231c48c036f8f1f951344f29da1dc9
 SRC_URI += "\
   file://patches/0301-iio-adc-add-buffering-support-to-the-TI-LMP92064-ADC.patch \
   "
-# umpf-release: 6.5/customers/lxa/lxatac/20230901-1
-# umpf-topic-range: 1023956dbecbb04c6edcb1c38229034800a2b4e9..1dd0a96389ccc12d1fe5cb4b15ab0aa7109246f4
+# umpf-release: 6.5/customers/lxa/lxatac/20230901-2
+# umpf-topic-range: 5f3889a4a5231c48c036f8f1f951344f29da1dc9..6eb45c5edee20824a6ce46a025f26af1c6367362
 SRC_URI += "\
-  file://patches/0401-Release-6.5-customers-lxa-lxatac-20230901-1.patch \
+  file://patches/0401-Release-6.5-customers-lxa-lxatac-20230901-2.patch \
   "
 # umpf-end

--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "77944468f9827167ef9e6bc4c628506c77a580b7"
+SRCREV = "16391c2af5798f9ddcef36f3e26c0510e80a538a"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -4,7 +4,7 @@ SRC_URI = " \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "77944468f9827167ef9e6bc4c628506c77a580b7"
+SRCREV = "16391c2af5798f9ddcef36f3e26c0510e80a538a"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This PR improves the EMI performance of the TAC (at least when measuring the emissions on pins of the IOBus port in isolation).

How can that be you ask? The VCC_IO supply line powering all of the SoC's GPIO pins is necessarily affected by high frequency switching of e.g. the RGMII and eMMC lines. This results in GPIOs that are actively driven high also containing said noise.
This PR makes it so that the lines are never driven high by the SoC, relying instead on pull-up resistors on the power board.

Related Pull Requests
---------------

This PR is based on other PRs that should be merged first:

- [ ] The `meta-lxatac` pull request that last touched the kernel patch stack: #52 
- [x] The `tacd` pull request that drives the GPIOs as open drain linux-automation/tacd#31

[1]: https://lore.kernel.org/linux-arm-kernel/20230112112013.1086787-1-u.kleine-koenig@pengutronix.de/