### PR TITLE
oe-init-build-env: make script independent of `pwd`

### DIFF
--- a/oe-init-build-env
+++ b/oe-init-build-env
@@ -11,9 +11,12 @@ else
     echo "  exec bash -c \"source oe-init-build-env && exec fish\""
     exit 1
 fi
+
 DIR=$( dirname -- "${THIS_SCRIPT}" )
+DIR=$( readlink -f "${DIR}" )
 unset THIS_SCRIPT
 
-TEMPLATECONF=${DIR}/meta-lxatac-software/conf/templates/default/
+TEMPLATECONF="${DIR}/meta-lxatac-software/conf/templates/default/"
 
-. ${DIR}/poky/oe-init-build-env $1
+# shellcheck source=poky/oe-init-build-env
+. "${DIR}/poky/oe-init-build-env" "$1"

--- a/oe-init-build-env
+++ b/oe-init-build-env
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
-TEMPLATECONF=`pwd`/meta-lxatac-software/conf/templates/default/
+if [ -n "${BASH_SOURCE[0]}" ]; then
+    THIS_SCRIPT="${BASH_SOURCE[0]}"
+elif [ -n "$ZSH_NAME" ]; then
+    THIS_SCRIPT="$0"
+else
+    echo "The meta-lxatac oe-init-build-env can only be sourced by bash and zsh."
+    echo "For other shells (e.g. fish) use a workaround like the following:"
+    echo
+    echo "  exec bash -c \"source oe-init-build-env && exec fish\""
+    exit 1
+fi
+DIR=$( dirname -- "${THIS_SCRIPT}" )
+unset THIS_SCRIPT
 
-. poky/oe-init-build-env $1
+TEMPLATECONF=${DIR}/meta-lxatac-software/conf/templates/default/
+
+. ${DIR}/poky/oe-init-build-env $1


### PR DESCRIPTION
Hi,
this is only a slight change in the `oe-init-build-env` that removes the requirement to source the script from `meta-lxatac`.
Thus it works fine with crops/yocto containers:
```bash
# Podman
podman run --rm --tty --interactive \
  --userns=keep-id --user $(id -u):$(id -g) \
  --env HOME=/tmp --tmpfs /tmp \
  --volume $(pwd)/meta-lxatac:$(pwd)/meta-lxatac \
  ghcr.io/crops/yocto:debian-10-builder \
  --pokydir $(pwd)/meta-lxatac --target lxatac-core-bundle-base --builddir $(pwd)/meta-lxatac/build
```