### PR TITLE
emmc-image: remove size workaround

### DIFF
--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -8,7 +8,7 @@ image @IMAGE@img {
     size = 2G
     hdimage {
         align = 1M
-        gpt = "true"
+        partition-table-type = gpt
         fill = true
     }
 

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -5,9 +5,11 @@ image @IMAGE@simg {
 }
 
 image @IMAGE@img {
+    size = 2G
     hdimage {
         align = 1M
         gpt = "true"
+        fill = true
     }
 
     partition reserved {
@@ -20,14 +22,7 @@ image @IMAGE@img {
         image = "root-fs-@IMAGE@ext4"
         partition-type-uuid = "69dad710-2ce4-4e3c-b16c-21a1d49abed3"
         partition-uuid = "e82e6873-62cc-46fb-90f0-3e936743fa62"
-        size = 2048M
-    }
-
-    partition end {
-        image = "/dev/null"
-        offset = 2050M
-        size = 1M
-        in-partition-table = false
+        size = 2045M
     }
 }
 
@@ -38,5 +33,5 @@ image root-fs-@IMAGE@ext4 {
     }
 
     mountpoint = "/"
-    size = 2048M
+    size = 2045M
 }


### PR DESCRIPTION
genimage knows about the 'size' option for images to fill the image to a certain size, and since genimage v14 it supports the 'fill' option to write all zeroes at the end of the image and not cut them off to optimise image size. Use this to blow up the images to the full 2 GiB, and remove our invisible-partition-at-the-end hack.