### PR TITLE
GitHub/GitLab Action/Pipeline Runners

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -75,6 +75,7 @@ case "$1" in
 		migrate /etc/labgrid/userconfig.yaml
 		migrate /etc/github-act-runner/sessions.json
 		migrate /etc/github-act-runner/settings.json
+		migrate /etc/gitlab-runner/config.toml
 		for x in /etc/ssh/ssh_host*; do
 			migrate "${x}"
 		done

--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -73,6 +73,8 @@ case "$1" in
 		migrate /etc/machine-id
 		migrate /etc/labgrid/environment
 		migrate /etc/labgrid/userconfig.yaml
+		migrate /etc/github-act-runner/sessions.json
+		migrate /etc/github-act-runner/settings.json
 		for x in /etc/ssh/ssh_host*; do
 			migrate "${x}"
 		done

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -46,6 +46,7 @@ IMAGE_INSTALL:append = "\
     gdbserver \
     git \
     github-act-runner \
+    gitlab-runner \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad-videoparsersbad \
     gstreamer1.0-plugins-base \

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL:append = "\
     gdb \
     gdbserver \
     git \
+    github-act-runner \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad-videoparsersbad \
     gstreamer1.0-plugins-base \

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/files/github-act-runner.service
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/files/github-act-runner.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Schedule GitHub actions to run on this TAC
+ConditionPathExists=/etc/github-act-runner/settings.json
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/github-act-runner run
+Environment="XDG_CACHE_HOME=/srv/github-act-runner"
+WorkingDirectory=/etc/github-act-runner
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
@@ -1,0 +1,29 @@
+SUMMARY = "GitHub act Runner"
+DESCRIPTION = "Alternative implementation of the GitHub Action runner protocol written in Go"
+
+SRC_URI = " \
+    git://github.com/ChristopherHX/github-act-runner.git;branch=main;protocol=https \
+    file://github-act-runner.service \
+"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit go-mod
+inherit systemd
+
+GO_IMPORT = "github.com/ChristopherHX/github-act-runner"
+
+RDEPENDS:${PN}:append = "nodejs"
+RDEPENDS:github-act-runner-dev:append = "make bash"
+
+SYSTEMD_SERVICE:${PN} = "github-act-runner.service"
+
+# This is required because the go build system fetches dependecies in the
+# compile stage.
+do_compile[network] = "1"
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/github-act-runner.service ${D}${systemd_system_unitdir}/
+}

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.6.7.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.6.7.bb
@@ -1,0 +1,3 @@
+require github-act-runner.inc
+
+SRCREV = "2a2c5ff501cc894daaf4a333d829419802a9abca"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/files/gitlab-runner.service
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/files/gitlab-runner.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Schedule GitLab actions to run on this TAC
+ConditionPathExists=/etc/gitlab-runner/config.toml
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/gitlab-runner run
+WorkingDirectory=/srv
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
@@ -1,0 +1,30 @@
+SUMMARY = "GitLab Runner"
+DESCRIPTION = "The Runner for GitLab Pipelines"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI:append = " file://gitlab-runner.service "
+
+GO_IMPORT = "gitlab.com/gitlab-org/gitlab-runner"
+GO_INSTALL = "${GO_IMPORT}"
+
+RDEPENDS:gitlab-runner-dev = "bash"
+
+inherit go-mod
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "gitlab-runner.service"
+
+# This is required because the go build system fetches dependecies in the
+# compile stage.
+do_compile[network] = "1"
+
+# This is required to prevent build failures due to
+# "duplicated definition of symbol" errors.
+GO_LINKSHARED = ""
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/gitlab-runner.service ${D}${systemd_system_unitdir}/
+}

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_16.6.1.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_16.6.1.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRC_URI = "git://gitlab.com/gitlab-org/gitlab-runner.git;branch=16-6-stable;protocol=https"
+SRCREV = "f5da3c5adf55e55004e0dae2a2e1476f8407c087"


### PR DESCRIPTION
This allows registering the TAC itself as a GitHub/GitLab runner. Once registered the TAC can be used to flash artifacts onto a DUT and execute tests.

Having this feature makes the TAC a lot more useful (in my opinion) but one has to keep in mind that using it makes the TAC effectively a backdoor into your infrastructure for whoever runs you GitHub/GitLab infrastructure.
I have some ideas on how to mitigate this a bit (run the runner services in network namespaces and as normal users with adequate permissions and firewalling), but these are not implemented in this PR.

Handle with care

TODO
----

- [x] Add service files (disabled by default) to start the runners.
  - [x] GitHub Runner
  - [x] GitLab Runner
- [x] Play around a bit more with the runners.
- [x] Investigate the build time and image size impact of this PR. The go binaries feel a bit heavy.
  - The build time increase of the Go binaries is not that bad, as we already have a Go toolchain for e.g. podman.
  - The build time increase for the target nodejs is a bit annoying though
  - The size of the RAUC bundle increased from `229M` to `268M` (`39M` or 17% larger than before). Not great, but for the feature well worth it, I guess.