### PR TITLE
meta-lxatac-bsp: rauc: resize partitions after writing them

### DIFF
--- a/meta-lxatac-bsp/recipes-core/rauc/files/lxatac/system.conf
+++ b/meta-lxatac-bsp/recipes-core/rauc/files/lxatac/system.conf
@@ -11,11 +11,13 @@ directory=certificates-enabled
 device=/dev/disk/by-partuuid/e82e6873-62cc-46fb-90f0-3e936743fa62
 type=ext4
 bootname=system0
+resize=true
 
 [slot.rootfs.1]
 device=/dev/disk/by-partuuid/8eb3e87e-2b4e-45e3-888b-2f678662862d
 type=ext4
 bootname=system1
+resize=true
 
 [slot.bootloader.0]
 device=/dev/mmcblk1

--- a/meta-lxatac-bsp/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/rauc/rauc_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-RDEPENDS:${PN}:append = "bash"
+RDEPENDS:${PN}:append = "bash e2fsprogs-resize2fs"
 
 SRC_URI:append = " \
     file://require-mount-srv.conf \


### PR DESCRIPTION
We've discovered that LXA TACs only filled the whole root parition with a filesystem on the initial deploy, but not for subsequent RAUC updates. As it turns out we were missing the resize flag in system.conf.

Fix that.

TODO before merging:

- [x] ~~The current bundles do not ship a `resize2fs`, making installation of bundles built with this impossible. Find and implement a workaround (like installing the `resize2fs` shipped in the bundle in a hook)~~ Nope. This was just me being confused. The PR works just fine as-is.