### PR TITLE
meta-lxatac-software: labgrid-exporter: more specific usb serial match

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -88,7 +88,7 @@ lxatac-usb-ports-p{{idx}}:
       '@ID_PATH': '{{sysfs}}'
   USBSerialPort:
     match:
-      '@ID_PATH': '{{sysfs}}'
+      '@ID_PATH': '{{sysfs}}:1.0'
   USBVideo:
     match:
       '@ID_PATH': '{{sysfs}}'

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -95,8 +95,8 @@ lxatac-usb-ports-p{{idx}}:
 ## Extra USB Ports exported as separate interfaces on the same USB port
 {% for if in [ '1', '2', '3'] %}
 lxatac-usb-ports-p{{idx}}.{{if}}:
-   USBSerialPort:
-     match:
-       '@ID_PATH': '{{sysfs}}:1.{{if}}'
+  USBSerialPort:
+    match:
+      '@ID_PATH': '{{sysfs}}:1.{{if}}'
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
The less-specific `{{sysfs}}` match also matches on `{{sysfs}}:1.1`, `{{sysfs}}:1.2`, `{{sysfs}}:1.3` etc..
This results in labgrid being rightfully confused about udev events for said devices.

Match on the more specific `{{sysfs}}:1.0` instead.

A side-effect of this change is that the first port is now exported as `lxatac-usb-ports-p1.0` instead of `lxatac-usb-ports-p1`.

This fixes #66.