### PR TITLE
meta-lxatac-software: android-tools: do not use host /usr in libext4_utils

### DIFF
--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libext4_utils.mk-do-not-use-host-usr-include.patch
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools/0001-libext4_utils.mk-do-not-use-host-usr-include.patch
@@ -1,0 +1,34 @@
+From 67be5bea10c91edb6d4ce968892f9774d7942baa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Fri, 27 Oct 2023 08:19:51 +0200
+Subject: [PATCH] libext4_utils.mk: do not use host /usr/include
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without this patch the build rightfully fails with:
+
+  cc1plus: error: include location "/usr/include/android" is unsafe for
+    cross-compilation [-Werror=poison-system-directories]
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ debian/libext4_utils.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/libext4_utils.mk b/debian/libext4_utils.mk
+index 2e93158..6803586 100644
+--- a/debian/libext4_utils.mk
++++ b/debian/libext4_utils.mk
+@@ -18,7 +18,7 @@ CPPFLAGS += \
+             -Iext4_utils/include \
+             -Ilibfec/include \
+             -Isquashfs_utils \
+-            -I/usr/include/android -I$(OUT_DIR)/usr/include \
++            -I$(OUT_DIR)/usr/include \
+             -D_GNU_SOURCE -DFEC_NO_KLOG -DSQUASHFS_NO_KLOG -D_LARGEFILE64_SOURCE
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-- 
+2.39.2
+

--- a/meta-lxatac-software/recipes-devtools/android-tools/android-tools_10.0.0.r36.bb
+++ b/meta-lxatac-software/recipes-devtools/android-tools/android-tools_10.0.0.r36.bb
@@ -85,6 +85,7 @@ SRC_URI += " \
     file://0001-patching-libundwind-to-build-in-yocto-environment.patch;patchdir=external/libunwind \
     file://0001-libext4_utils.mk-modifications-to-make-it-build-in-y.patch;patchdir=system/extras \
     file://0002-libfec-change-out_dir-in-makefile.patch;patchdir=system/extras \
+    file://0001-libext4_utils.mk-do-not-use-host-usr-include.patch;patchdir=system/extras \
     file://rules_yocto.mk;subdir=git \
     file://android-tools-adbd.service \
     file://adbd.mk;subdir=git/system/core/debian \


### PR DESCRIPTION
Without this patch the build rightfully fails with:

```
cc1plus: error: include location "/usr/include/android" is unsafe for cross-compilation [-Werror=poison-system-directories]
```

This issue was discovered by @ukleinek when building the BSP from scratch, which we do not usually do (but maybe should do to discover these kinds of issues).