### PR TITLE
meta-lxatac-bsp: emmc-image: build smaller images (faster)

### DIFF
--- a/meta-lxatac-bsp/recipes-core/images/emmc-image.bb
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image.bb
@@ -12,9 +12,7 @@ inherit genimage
 COMPATIBLE_MACHINE = "lxatac"
 
 GENIMAGE_IMAGE_SUFFIX = ""
-GENIMAGE_ROOTFS_IMAGE = "lxatac-core-image-base"
-GENIMAGE_ROOTFS_IMAGE_FSTYPE = "tar"
 
 do_genimage[depends] += " \
-    ${GENIMAGE_ROOTFS_IMAGE}:do_image_complete \
+    lxatac-core-image-base:do_image_complete \
 "

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -5,11 +5,9 @@ image @IMAGE@simg {
 }
 
 image @IMAGE@img {
-    size = 2G
     hdimage {
         align = 1M
         partition-table-type = gpt
-        fill = true
     }
 
     partition reserved {
@@ -22,7 +20,14 @@ image @IMAGE@img {
         image = "root-fs-@IMAGE@ext4"
         partition-type-uuid = "69dad710-2ce4-4e3c-b16c-21a1d49abed3"
         partition-uuid = "e82e6873-62cc-46fb-90f0-3e936743fa62"
-        size = 2045M
+        size = 2048M
+    }
+
+    partition end {
+        image = "/dev/null"
+        offset = 2050M
+        size = 1M
+        in-partition-table = false
     }
 }
 
@@ -33,5 +38,5 @@ image root-fs-@IMAGE@ext4 {
     }
 
     mountpoint = "/"
-    size = 2045M
+    size = 2048M
 }

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -8,6 +8,7 @@ image @IMAGE@img {
     hdimage {
         align = 1M
         partition-table-type = gpt
+        gpt-no-backup = true
     }
 
     partition reserved {
@@ -21,13 +22,6 @@ image @IMAGE@img {
         partition-type-uuid = "69dad710-2ce4-4e3c-b16c-21a1d49abed3"
         partition-uuid = "e82e6873-62cc-46fb-90f0-3e936743fa62"
         size = 2048M
-    }
-
-    partition end {
-        image = "/dev/null"
-        offset = 2050M
-        size = 1M
-        in-partition-table = false
     }
 }
 

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -18,19 +18,9 @@ image @IMAGE@img {
     }
 
     partition root-a {
-        image = "root-fs-@IMAGE@ext4"
+        image = "lxatac-core-image-base-lxatac.ext4"
         partition-type-uuid = "69dad710-2ce4-4e3c-b16c-21a1d49abed3"
         partition-uuid = "e82e6873-62cc-46fb-90f0-3e936743fa62"
         size = 2048M
     }
-}
-
-image root-fs-@IMAGE@ext4 {
-    ext4 {
-        label = "root-fs"
-        use-mke2fs = true
-    }
-
-    mountpoint = "/"
-    size = 2048M
 }

--- a/meta-lxatac-bsp/recipes-core/systemd/files/systemd-growfs-root.service
+++ b/meta-lxatac-bsp/recipes-core/systemd/files/systemd-growfs-root.service
@@ -1,0 +1,23 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Grow Root File System
+Documentation=man:systemd-growfs-root.service(8)
+
+DefaultDependencies=no
+After=systemd-repart.service systemd-remount-fs.service
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/systemd/systemd-growfs /
+TimeoutSec=infinity

--- a/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://systemd-growfs-root.service \
+"
+
 RRECOMMENDS:${PN}:append = "less"
 # Enable lz4 and seccomp for systemd
 PACKAGECONFIG:append = "lz4 seccomp coredump elfutils"
@@ -14,4 +20,14 @@ do_install:append() {
     # -> var-log-journal.mount
     mv ${D}${systemd_system_unitdir}/sysinit.target.wants/systemd-journal-flush.service	\
        ${D}${systemd_system_unitdir}/multi-user.target.wants/
+
+    # Starting with mickledore this file is provided by systemd and we can
+    # remove this.
+    install -m 0644 ${WORKDIR}/systemd-growfs-root.service \
+       ${D}${systemd_system_unitdir}
+
+    ln -s ../systemd-growfs-root.service \
+       ${D}${systemd_system_unitdir}/sysinit.target.wants/
 }
+
+FILES:${PN}:append = " ${systemd_system_unitdir}/systemd-growfs-root.service"


### PR DESCRIPTION
This PR does three things:

- Revert #62 by @rohieb because it did not achieve quite what we wanted
- Remove the `partition end` workaround that was removed in #62 (but without changing other things like adding `fill=true`).
- Do not place a GPT header at the "end"¹ of the image.
- Use the existing rootfs ext4 instead of generating a new one from the `.tar`.

Things I am not too sure about:

- [x] Should we use some templating magic instead of writing `lxatac-core-image-base-lxatac.ext4` in the `genimage.config`?
- [x] Are all the dependencies automatically set up so that we can rely on `lxatac-core-image-base-lxatac.ext4` being present.
     The first version of this PR used `GENIMAGE_ROOTFS_IMAGE` to specify this dependency. This is not quite correct. The `genimage.bbclass`  documentation states quite clearly that this variable is intended for `.tar` images that should be unpacked and re-packed into a filesystem image (thx @ejoerns ). Instead I've now set up the dependencies explicitly.
- [x] Is the rootfs grown like we want it to.

The last one I can test, for the rest I would be glad about some feedback.

---

¹ Which is the end of the image but has nothing to do with the end of the _device_ the image is written to, where the header should be.