### PR TITLE
meta-lxatac-bsp: emmc-image: clear barebox state on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,24 +500,3 @@ console via the debug UART adapter / the USB console provided by barebox
 and execute `wd -x` on the shell. E.g.:
 
     barebox@Linux Automation Test Automation Controller (TAC):/ wd -x
-
-##### The installed bundle does not start
-
-When flashing the emmc-image only the first of two update partitions is
-initialized. The second one is set up on first boot and filled for the first time
-once you install a RAUC bundle on the system for the first time.
-There is a 50/50 chance that barebox is currently set up to boot from this
-non-existing partition, which will fail and reduce its retry counter.
-If the TAC does not boot after flashing you should power cycle the device
-about four times in slow succession to make sure the wrong partition is marked
-as bad and the correct partition is used.
-
-Alternatively you can choose the correct partition using the barebox console
-via a UART debug adapter:
-
-    # state.bootstate.system1.remaining_attempts=0
-    # state.bootstate.system1.priority=0
-    # state.bootstate.system0.remaining_attempts=3
-    # state.bootstate.system0.priority=1
-    # state -s
-    # reset

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-a
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-a
@@ -5,11 +5,11 @@ led led-status-red 0
 led led-status-green 252
 led led-status-blue 97
 
-echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root0 ..."
+echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-a ..."
 
-boot -v mmc1.1
+boot -v mmc1.root-a
 
 # Show splash screen with red background on error
 splash -b 0xffcd0000 /env/data/splash.png
 
-echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root0!"
+echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root-a!"

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-b
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-b
@@ -5,11 +5,11 @@ led led-status-red 0
 led led-status-green 252
 led led-status-blue 97
 
-echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root1 ..."
+echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-b ..."
 
-boot -v mmc1.2
+boot -v mmc1.root-b
 
 # Show splash screen with red background on error
 splash -b 0xffcd0000 /env/data/splash.png
 
-echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root1!"
+echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root-b!"

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/nv/bootchooser.system0.boot
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/nv/bootchooser.system0.boot
@@ -1,1 +1,1 @@
-root0
+root-a

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/nv/bootchooser.system1.boot
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/nv/bootchooser.system1.boot
@@ -1,1 +1,1 @@
-root1
+root-b

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image.bb
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image.bb
@@ -13,6 +13,23 @@ COMPATIBLE_MACHINE = "lxatac"
 
 GENIMAGE_IMAGE_SUFFIX = ""
 
+# This can be removed once we have a genimage with fill= support
+GENIMAGE_VARIABLES[WORKDIR] = "${WORKDIR}"
+
+do_configure:append() {
+    # This can be removed once we have a genimage with fill= support.
+    # Just using /dev/zero in the genimage config does not work because ...
+    #
+    # $ python3
+    # >>> import os
+    # >>> os.stat("/dev/zero")
+    # os.stat_result(st_mode=8630 ... st_size=0 ..)
+    #
+    # ... /dev/zero has 0 size and genimage only writes st_size bytes of
+    # the file into the image and leaves the rest sparse.
+    dd if=/dev/zero bs=1024 count=256 of=${WORKDIR}/state-filler.img
+}
+
 do_genimage[depends] += " \
     lxatac-core-image-base:do_image_complete \
 "

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -6,9 +6,34 @@ image @IMAGE@simg {
 
 image @IMAGE@img {
     hdimage {
-        align = 1M
         partition-table-type = gpt
         gpt-no-backup = true
+    }
+
+    partition barebox-env {
+        image = "@WORKDIR@/state-filler.img"
+        in-partition-table = false
+        offset = 512K
+        size = 256K
+    }
+
+    partition barebox-state {
+        image = "@WORKDIR@/state-filler.img"
+        # We can not have the barebox partitions in the partition table right
+        # now because:
+        #  - If we add them the partition label clashes with the label of the
+        #    fixed partitions in the barebox devicetree.
+        #  - If we change the labels barebox still wont allow the partitions
+        #    to overlap.
+        #  - We have TACs in the wild that do not have the partitions,
+        #    in the partition table so we can not just remove the fixed
+        #    partitions in the barebox devicetree.
+        #    We thus need e.g. a RAUC hook that creates the partitions on
+        #    install.
+        in-partition-table = false
+        #partition-type-uuid = "4778ed65-bf42-45fa-9c5b-287a1dc4aab1"
+        offset = 768K
+        size = 256K
     }
 
     partition root-a {

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -11,16 +11,11 @@ image @IMAGE@img {
         gpt-no-backup = true
     }
 
-    partition reserved {
-        image = "/dev/null"
-        size = 1M
-        offset = 1M
-    }
-
     partition root-a {
         image = "lxatac-core-image-base-lxatac.ext4"
         partition-type-uuid = "69dad710-2ce4-4e3c-b16c-21a1d49abed3"
         partition-uuid = "e82e6873-62cc-46fb-90f0-3e936743fa62"
+        offset = 2M
         size = 2048M
     }
 }


### PR DESCRIPTION
The bootchooser info stored in the barebox state does not make any sense after installing a fresh image via `fastboot`
(see the removed `README.md` section for more details).

Make sure the barebox state part of the `emmc-image-lxatac.simg` sparse image was touched during image generation so it is not marked as sparse and thus skipped when flashing.

There are also preparations to expose the barebox state as a partition with the correct type `UUID`, but that requires some changes to the barebox devicetree because as of now it tries to add the state twice and fails the second time.

Todo before merging:

- [x] Check if the later partitions (`root-a`, `root-b`, `data`) did not shift around and their alignment is still the same.
  2023-11-10: Partition numbering did indeed change, but this is less of a problem now that we have label-based boot slot selection.
- [x] Check if the barebox state and environment are cleared as intended.
- [x] Remove the workarounds for invalid barebox state from the testsuite