### PR TITLE
dependabot: add configuration to update layer submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    commit-message:
+      prefix: "meta-*: "
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    groups:
+      layers:
+        patterns:
+          - "meta-*"
+          - "poky"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "meta-ptx"]
 	path = meta-ptx
 	url = https://github.com/pengutronix/meta-ptx.git
-	branch = langdale
+	branch = master
 [submodule "meta-oe"]
 	path = meta-oe
 	url = https://github.com/openembedded/meta-openembedded.git


### PR DESCRIPTION
This should result in us getting regular pull requests like these:

![dependabot](https://github.com/linux-automation/meta-lxatac/assets/1273320/3f2063d0-22d3-4a8a-9470-56ca22d66680)

So we can stay up to date without having to poll the submodules on our own.

It obviously does not free us from having to test the result and review the changes. But one thing at a time.

Thanks to @KarlK90 for the inspiration to do this.