### PR TITLE
meta-lxatac-software: tacd: create /srv/www in tacd.service

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/files/tacd.service
+++ b/meta-lxatac-software/recipes-rust/tacd/files/tacd.service
@@ -6,6 +6,7 @@ RequiresMountsFor=/srv/tacd
 [Service]
 Type=notify
 Environment="RUST_LOG=tacd=warn"
+ExecStartPre=mkdir -p /srv/www
 ExecStart=/usr/bin/tacd
 TimeoutStartSec=20
 Restart=on-failure


### PR DESCRIPTION
The content of the `/srv/www` directory is exported by the tacd via HTTP. If this directory does not exist the user gets a (true, but somewhat confusing) `404 Not Found` error if they try to access `/srv` via HTTP.

Usually a tmpfiles.d entry would be the way to go to create this directory, but it causes issues for directories on the /srv file system. See this comment copied from a similar commit (36d7cf538c7) for `atftp.service`:

> The tmpfiles.d service runs very early in the boot process and even before system-update.target. This means it would clutter the /srv directory in the rootfs if the /srv partition was not yet mounted - because it was not generated yet by systemd-repart.