### PR TITLE
CI: fix distribution version consistency checks

### DIFF
--- a/.github/workflows/distribution-version.py
+++ b/.github/workflows/distribution-version.py
@@ -67,17 +67,19 @@ def check_version(distro_version):
 
 def check_codename(codename):
     base_ref = os.environ.get("GITHUB_BASE_REF")
-    ref = os.environ.get("GITHUB_REF")
+    ref = os.environ.get("GITHUB_REF_NAME")
+    ref_type = os.environ.get("GITHUB_REF_TYPE")
 
-    if base_ref is not None:
+    if base_ref:
         print(f"Checking codename {codename} against pull request into {base_ref}")
         assert codename == f"tacos-{base_ref}"
-    elif ref is not None:
+    elif ref and ref_type == "branch":
         print(f"Checking codename {codename} against branch {ref}")
         assert codename == f"tacos-{ref}"
+    elif ref_type == "tag":
+        print("Running for a tag. Skipping codename check")
     else:
         print("Running outside of GitHub CI. Skipping codename check")
-        return
 
 
 def main():


### PR DESCRIPTION
To follow a well honored tradition our first CI job we added failed instantly when it landed in the main branch.
Now that the traditions have been honored we can fix it.

There were multiple things wrong with the previous version regarding CI jobs running for a branch or tag (instead of jobs running for a pull request):

  - The `GITHUB_REF` variable contains a name like "refs/heads/mickledore", not just "mickledore". We want `GITHUB_REF_NAME`.
  - The `GITHUB_BASE_REF` variable is also set for non pull request jobs, but it is set to an empty string. Check for that to decide if we are running in "pull request mode".
  - When running for a tag the branch name check for the os codename does not make sense. Skip it in that case.

Fixes #87 