### PR TITLE
meta-lxatac-bsp: libtraceevent: backport "build with Meson" from oe-core

### DIFF
--- a/meta-lxatac-bsp/recipes-backport/libtraceevent/libtraceevent/meson.patch
+++ b/meta-lxatac-bsp/recipes-backport/libtraceevent/libtraceevent/meson.patch
@@ -1,0 +1,74 @@
+Fixes for the Meson build of libtraceevent:
+
+- Make the plugin directory the same as the Makefiles
+- Install the plugins as modules not static and versioned shared libraries
+- Add an option to disable building the documentation (needs asciidoc and xmlto)
+
+Upstream-Status: Pending
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+
+diff --git a/meson.build b/meson.build
+index b61c873..4bba4d8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -25,7 +25,7 @@ htmldir = join_paths(prefixdir, get_option('htmldir'))
+ libdir = join_paths(prefixdir, get_option('libdir'))
+ plugindir = get_option('plugindir')
+ if plugindir == ''
+-    plugindir = join_paths(libdir, 'libtraceevent/plugins')
++    plugindir = join_paths(libdir, 'traceevent/plugins')
+ endif
+ 
+ add_project_arguments(
+@@ -45,10 +45,13 @@ if cunit_dep.found()
+     subdir('utest')
+ endif
+ subdir('samples')
+-subdir('Documentation')
+ 
+-custom_target(
+-    'docs',
+-    output: 'docs',
+-    depends: [html, man],
+-    command: ['echo'])
++if get_option('docs')
++    subdir('Documentation')
++
++    custom_target(
++        'docs',
++        output: 'docs',
++        depends: [html, man],
++        command: ['echo'])
++endif
+diff --git a/meson_options.txt b/meson_options.txt
+index b2294f6..0611216 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -4,6 +4,10 @@
+ 
+ option('plugindir', type : 'string',
+        description : 'set the plugin dir')
++
++option('docs', type : 'boolean', value: true,
++       description : 'build documentation')
++
+ option('htmldir', type : 'string', value : 'share/doc/libtraceevent-doc',
+        description : 'directory for HTML documentation')
+ option('asciidoctor', type : 'boolean', value: false,
+diff --git a/plugins/meson.build b/plugins/meson.build
+index 74ad664..4919be4 100644
+--- a/plugins/meson.build
++++ b/plugins/meson.build
+@@ -19,11 +19,10 @@ plugins = [
+ 
+ pdeps = []
+ foreach plugin : plugins
+-    pdeps += library(
++    pdeps += shared_module(
+         plugin.replace('.c', ''),
+         plugin,
+         name_prefix: '',
+-        version: library_version,
+         dependencies: [libtraceevent_dep],
+         include_directories: [incdir],
+         install: true,

--- a/meta-lxatac-bsp/recipes-backport/libtraceevent/libtraceevent_1.7.3.bb
+++ b/meta-lxatac-bsp/recipes-backport/libtraceevent/libtraceevent_1.7.3.bb
@@ -1,0 +1,23 @@
+# Copyright (C) 2022 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "API to access the kernel tracefs directory"
+HOMEPAGE = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://LICENSES/GPL-2.0;md5=e6a75371ba4d16749254a51215d13f97 \
+                    file://LICENSES/LGPL-2.1;md5=b370887980db5dd40659b50909238dbd"
+SECTION = "libs"
+
+SRCREV = "dd148189b74da3e2f45c7e536319fec97cb71213"
+SRC_URI = "git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git;branch=${BPN};protocol=https \
+           file://meson.patch"
+
+S = "${WORKDIR}/git"
+
+inherit meson pkgconfig
+
+EXTRA_OEMESON = "-Ddocs=false"
+
+PACKAGES += "${PN}-plugins"
+
+FILES:${PN}-plugins += "${libdir}/traceevent/plugins"


### PR DESCRIPTION
This fixes an issue where the libtraceevent build would sometimes generate .so files with some objects missing due to a [race condition in the Makefile](https://git.yoctoproject.org/poky/commit/?id=142b6921bde5b22bcd7e0e5e8d895575d0fb6c64).
One of these builds made it into the sstate of our CI builds, making them fail.

The upstream fix is to just move to meson as a build system, so lets just do the same.

This only affects our mickledore branch, as the backport comes from the nanbield poky branch (and langdale did not use libtraceevent).

Thanks to @ejoerns for finding the respective oe-core patch!