### PR TITLE
meta-lxatac-software: bcu: add recipe for nxp board control utilities

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -24,6 +24,7 @@ IMAGE_INSTALL:append = "\
     android-tools \
     avahi-utils \
     barebox-tools \
+    bcu \
     blktrace \
     bluez5 \
     bmap-tools \

--- a/meta-lxatac-software/recipes-devtools/bcu/bcu/0001-CMakeLists-do-not-use-vendored-libcurl.patch
+++ b/meta-lxatac-software/recipes-devtools/bcu/bcu/0001-CMakeLists-do-not-use-vendored-libcurl.patch
@@ -1,0 +1,38 @@
+From ef1aaeee984ab13dab5d46c73e9b207cbdf62c55 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Wed, 20 Dec 2023 14:37:20 +0100
+Subject: [PATCH] CMakeLists: do not use vendored libcurl
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream-Status: Inappropriate [upstream ticket https://github.com/nxp-imx/bcu/issues/17]
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3475179..bfecdb0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,15 +17,16 @@ pkg_check_modules(LIBFTDI REQUIRED libftdi1)
+ pkg_check_modules(LIBYAML REQUIRED yaml-0.1)
+ pkg_check_modules(LIBOPENSSL REQUIRED openssl)
+ pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
++pkg_check_modules(LIBCURL REQUIRED libcurl)
+ project(bcu)
+-include_directories(${LIBUSB_INCLUDE_DIRS} ${LIBFTDI_INCLUDE_DIRS}include ${PROJECT_SOURCE_DIR}/libftdi/src ${LIBYAML_INCLUDEDIR} ${PROJECT_SOURCE_DIR}/libcurl/include)
++include_directories(${LIBUSB_INCLUDE_DIRS} ${LIBFTDI_INCLUDE_DIRS}include ${LIBYAML_INCLUDEDIR})
+ include_directories(${PROJECT_SOURCE_DIR})
+ 
+ message("operation system is ${CMAKE_SYSTEM}")
+ if (LINUX)
+         add_executable(bcu bcu.c port.c chip.c board.c bcu_parser.c bcu_yaml.c bcu_https.c bcu_ftdi_eeprom.c)
+         link_directories(${LIBUSB_LIBRARY_DIRS} ${LIBFTDI_LIBRARY_DIRS} ${LIBYAML_LIBRARY_DIRS})
+-        target_link_libraries (bcu ${LIBUSB_LIBRARIES} ${LIBFTDI_LIBRARIES} ${LIBYAML_LIBRARIES} ${PROJECT_SOURCE_DIR}/libcurl/build.bcu/lib/libcurl.a -lpthread -lssl -lcrypto -lm)
++        target_link_libraries (bcu ${LIBUSB_LIBRARIES} ${LIBFTDI_LIBRARIES} ${LIBYAML_LIBRARIES} -lcurl -lpthread -lssl -lcrypto -lm)
+         execute_process( COMMAND ${PROJECT_SOURCE_DIR}/create_version_h.sh ${PROJECT_SOURCE_DIR}
+                          COMMAND ${PROJECT_SOURCE_DIR}/build_libs.sh ${PROJECT_SOURCE_DIR})
+         install(TARGETS bcu DESTINATION bin)

--- a/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.75.bb
+++ b/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.75.bb
@@ -1,0 +1,14 @@
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=884d48c2aa7b82e1ad4a33909fab24b6"
+
+SRC_URI = "git://github.com/nxp-imx/bcu;protocol=https;branch=master \
+           file://0001-CMakeLists-do-not-use-vendored-libcurl.patch \
+           "
+SRCREV = "e3f9a83210260783e901d4973da8600be03bcf04"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "curl libyaml libusb1 openssl libftdi"
+
+inherit cmake pkgconfig
+


### PR DESCRIPTION
The `bcu` command is used to communicate with board control hardware on NXP development boards to:

  - reset / power cycle the board into a specified boot mode
  - monitor the power consumption
  - eeprom read / write
  - temperature measurements

Sadly [the board I tried to use this with](https://www.nxp.com/design/design-center/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadxplus-multisensory-enablement-kit-mek:MCIMX8QXP-CPU) is not actually supported, so I could only check that it builds and shows the help message.
It also discovered the FTDI device on the board, so that seems to work as well.