### PR TITLE
meta-lxatac-software: tacd{,-webinterface}: update

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "803b2084b26634542ebf763c818083884d49ac0d"
+SRCREV = "e94c996e95fc215ef86deb1dd130205582eafeaa"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -4,7 +4,7 @@ SRC_URI = " \
     "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "803b2084b26634542ebf763c818083884d49ac0d"
+SRCREV = "e94c996e95fc215ef86deb1dd130205582eafeaa"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This brings a couple of changes:

 - The RGB status LED is now dimmed a bit on idle via PWM. This makes all LEDs the same brightness on idle. When e.g. flashing the locator the status LED can however be made brighter than the other LEDs.
 - The Display now shows reboot notifications when the other RAUC slot would be booted on reboot. (Previously this check was based on which slot contained the newer image - even if the newer slot would not be booted after a suggested reboot).
 - The setup wizard was simplified. The "setup via rauc bundle" setup mode (that was not implemented yet) was removed. There is now only one setup method.
 - The tacd now asks for consent before polling for updates from the update server.
 - The misleading "Your TAC is overheating" warning if the connection between the web interface and tacd server breaks should be gone.