### PR TITLE
meta-lxatac-software/containers: Update to debian:latest

### DIFF
--- a/meta-lxatac-software/recipes-devtools/containers/files/container-update.sh
+++ b/meta-lxatac-software/recipes-devtools/containers/files/container-update.sh
@@ -21,6 +21,6 @@ else
 	exit 2
 fi
 
-podman pull debian:bullseye
+podman pull debian:latest
 
 exit 0


### PR DESCRIPTION
This effectively bumps the Debian version to the most recent release at that time.
This way we will not need to update the script with every Debian release.

This also aligns the behavior with `container-start.sh` that simply pulls `debian` if no container is present.
And this also defaults to `latest`.