### PR TITLE
README: Add contribution guidelines with DCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Main topics:
   - [Customization](#customization)
   - [Setting up a Bundle Server](#bundle-server)
   - [Installing Images via USB](#installing-images-via-usb)
+  - [Contributing](#contributing)
 
 This set of recipes is used to build the software images and update bundles
 for the LXATAC provided by the Linux Automation GmbH. It can be used to
@@ -531,3 +532,46 @@ console via the debug UART adapter / the USB console provided by barebox
 and execute `wd -x` on the shell. E.g.:
 
     barebox@Linux Automation Test Automation Controller (TAC):/ wd -x
+
+Contributing
+------------
+
+Thank you for thinking about contributing to this project!
+Changes should be submitted via a
+[Github pull request](https://github.com/linux-automation/meta-lxatac/pulls).
+
+This project uses the [Developer's Certificate of Origin 1.1](https://developercertificate.org/) with the same 
+[process](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin)
+as used for the Linux kernel:
+
+    Developer's Certificate of Origin 1.1
+    
+    By making a contribution to this project, I certify that:
+    
+    (a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+    
+    (b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+    
+    (c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+    
+    (d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+Then you just add a line (using ``git commit -s``) saying:
+
+    Signed-off-by: Random J Developer <random@developer.example.org>
+
+using a known identity (sorry, no anonymous contributions).


### PR DESCRIPTION
We want to help new contributors help find their way to the 'Pull Request' tab.

Also we want contributions to contain a DCO.