### PR TITLE
meta-lxatac-bsp: lxatac-factory-data: reload udev rules on completion

### DIFF
--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
@@ -67,3 +67,5 @@ MACAddress=${MAC_BRIDGE}
 MACAddressPolicy=none
 EOF
 
+# Make sure that the link file is used
+udevadm control --reload-rules


### PR DESCRIPTION
The lxatac-factory-data script generates a tac-bridge.link file, which sets the MAC address to use on the tac-bridge network interface, which is a bridge created by NetworkManager.

We have noticed that on some boots this MAC address is not correct. On these boots we can also see that udev (which reads the .link files) did not take the link file into account (even though it exists):

Normal boot:

    # udevadm info /sys/class/net/tac-bridge | grep LINK_FILE
    ID_NET_LINK_FILE=/run/systemd/network/10-tac-bridge.link

Boot with wrong MAC address:

    # udevadm info /sys/class/net/tac-bridge | grep LINK_FILE
    ID_NET_LINK_FILE=/usr/lib/systemd/network/99-default.link

This hints at some sort of race condition between lxatac-factory-data, udev reading its rules and NetworkManager setting up the bridge device.

Run `udevadm control --reload-rules` after creating the link file to hopefully solve the race condition.

I did some "statistical" testing of this change by running our labgrid pytest test in a loop, which checks if the MAC is correct:

    # Before this change the interface has the correct MAC
    # 14 / (14 + 6) = 70% of the time.
    14 before/success
     6 before/failure

    # After this change the interface has the correct MAC
    # in all 21 runs.
    21 udevadm-reload/success
     0 udevadm-reload/failure

    # When replacing the `udevadm control --reload-rules` with
    # just a `sleep 1` the MAC address is still correct in all 22
    # runs, but the IPv6 link local address of the interface contains
    # the wrong MAC address.
    20 sleep/success
     2 sleep/failure

The tests indicate that the fix works, but are not 100% clear as to it working for the correct reasons (because just waiting also helps a bit).