### PR TITLE
lxatac-core-image-base: Apply Some Cleanups

### DIFF
--- a/meta-lxatac-bsp/recipes-core/images/lxatac-core-image-base.bbappend
+++ b/meta-lxatac-bsp/recipes-core/images/lxatac-core-image-base.bbappend
@@ -9,5 +9,3 @@ IMAGE_INSTALL:append = "\
     kernel-devicetree \
     dt-utils-barebox-state \
 "
-
-ROOTFS_POSTPROCESS_COMMAND += " make_zimage_symlink_relative; "

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -7,7 +7,7 @@ MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"
 
 LOCALCONF_VERSION = "2"
 
-DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr nfs zeroconf multiarch systemd usrmerge"
+DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi bluetooth xattr nfs zeroconf multiarch systemd usrmerge"
 DISTRO_FEATURES += " rauc virtualization ipv6 security seccomp alsa polkit"
 
 # Select systemd as init manager

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -65,7 +65,6 @@ IMAGE_INSTALL:append = "\
     iproute2-rtacct \
     iproute2-ss \
     iproute2-tc \
-    iw \
     libdrm-tests \
     libgpiod-tools \
     libiio \
@@ -98,7 +97,6 @@ IMAGE_INSTALL:append = "\
     openssh-sftp \
     openssh-sftp-server \
     openssl-engines \
-    packagegroup-base-wifi \
     perf \
     ply \
     podman \

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -26,7 +26,6 @@ IMAGE_INSTALL:append = "\
     barebox-tools \
     bcu \
     blktrace \
-    bluez5 \
     bmap-tools \
     bonnie++ \
     bottom \

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -2,7 +2,7 @@ SUMMARY = "LXA TAC image containing a selection of useful development tools"
 
 BAD_RECOMMENDATIONS = "rng-tools"
 
-IMAGE_FEATURES = "ssh-server-openssh empty-root-password"
+IMAGE_FEATURES = "ssh-server-openssh empty-root-password tools-debug"
 
 IMAGE_FSTYPES += "ext4"
 
@@ -43,8 +43,6 @@ IMAGE_INSTALL:append = "\
     evtest \
     fb-test \
     fio \
-    gdb \
-    gdbserver \
     git \
     github-act-runner \
     gitlab-runner \
@@ -119,7 +117,6 @@ IMAGE_INSTALL:append = "\
     sispmctl \
     smemstat \
     socat \
-    strace \
     stress-ng \
     sysstat \
     systemd-analyze \


### PR DESCRIPTION
This is a first step into reducing the quite long and very explicit `IMAGE_INSTALL` list by oe-core default mechanisms like `IMAGE_FEATURES` and feature-controlled packagegroups.