### PR TITLE
CI: add a linting step for all of our custom bitbake recipes

### DIFF
--- a/.github/workflows/oe-stylize.sh
+++ b/.github/workflows/oe-stylize.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+FILES="$(find meta-lxatac-bsp/ meta-lxatac-software/ -type f -name \*.bb)"
+
+result="0"
+
+while read -r recipe
+do
+    # The oe-stylize script is not parameterizable, so we can not tell it not
+    # to output warnings about variables it does not know.
+    # Use grep to remove the warnings from its output.
+    python3 meta-oe/contrib/oe-stylize.py "${recipe}" | \
+        grep -v "## Warning: unknown variable/routine" > "${recipe}.linted"
+
+    diff --color=always "${recipe}" "${recipe}.linted" > "${recipe}.diff" \
+        && file_result="ok" || file_result="error"
+
+    if [[ "x${file_result}" != "xok" ]]
+    then
+        # Group the output in the GitHub log as it can become quite unwieldy
+        echo "::group::${recipe}"
+        cat "${recipe}.diff"
+        echo "::endgroup::"
+
+        result="1"
+    fi
+done <<< "${FILES}"
+
+exit "${result}"

--- a/.github/workflows/oe-stylize.yaml
+++ b/.github/workflows/oe-stylize.yaml
@@ -1,0 +1,18 @@
+name: oe-stylize
+
+on:
+  create: # tags and branches
+  pull_request:
+  push:
+jobs:
+  check:
+    name: lint recipes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Run oe-stylize for all recipes
+        run: .github/workflows/oe-stylize.sh


### PR DESCRIPTION
This PR is inspired by #110, which mentions running meta-openembedded's [`oe-stylize.py`](https://github.com/openembedded/meta-openembedded/blob/master/contrib/oe-stylize.py) on the bitbakes files in `meta-lxatac`.

Now that I have learned that there is a linter script for bitbake files I want it as a GitHub action.

So here is a pull request to add it.

TODO before merging:

  - [ ] Make sure the action runs without errors