### PR TITLE
meta-lxatac-bsp: lxatac-factory-data: order service before udev

### DIFF
--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.service
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Gather and Distribute Factory Data
-Before=NetworkManager.service
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=systemd-udevd.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/lxatac-factory-data
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
@@ -67,4 +67,3 @@ OriginalName=tac-bridge
 MACAddress=${MAC_BRIDGE}
 MACAddressPolicy=none
 EOF
-

--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
@@ -11,14 +11,14 @@ DST_LINK_FILE_BASE="/run/systemd/network/"
 mkdir -p "${DST_ENVS_BASE}"
 mkdir -p "${DST_LINK_FILE_BASE}"
 
-# Set the static hostname if it is not set yet
-# (The transient hostname is passed via systemd.hostname= commandline)
-# --------------------------------------------------------------------
+# If no hostname is set yet persist the one we currently have.
+# The hostname is passed in from the bootloader via the
+# systemd.hostname= kernel commandline and interpreted by init.
+# -------------------------------------------------------------
 
 if [[ ! -e /etc/hostname ]]
 then
-    hostname="$(hostnamectl --transient hostname)"
-    hostnamectl --static hostname "${hostname}"
+    hostname > /etc/hostname
 fi
 
 # Read Factory Data passed to us by barebox via the devicetree


### PR DESCRIPTION
This is an altternative to #107. Since both approaches are valid and have their benefits and drawbacks I made this a competing PR.

Order the factory data collecting service before the udev systemd service to make sure that the `.link` file it creates exists before udev starts looking for rules.

This should fix an issue we have that results in the `tac-bridge` interface having the wrong MAC address on some boots.

In contrast to #107 it does so without triggering udev to reload its rules.