### PR TITLE
meta-lxatac-software: lxatac-core-bundle-base: migrate /etc/hostname

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -71,6 +71,7 @@ case "$1" in
 		# installing from an eMMC image.
 		rm -f "${RAUC_SLOT_MOUNT_POINT}/system-update"
 
+		migrate /etc/hostname
 		migrate /etc/machine-id
 		migrate /etc/labgrid/environment
 		migrate /etc/labgrid/userconfig.yaml


### PR DESCRIPTION
We set default hostnames based on the serial number of the LXA TAC, (e.g. lxatac-00011) which is a sensible thing to do.

But users may want to set their own hostnames due to constraints of their infrastructure or just personal preference.

Enable them to do so persistently across RAUC updates.