### PR TITLE
meta-lxatac-bsp: emmc-image: specify image for state/env even with fill:

### DIFF
--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -11,6 +11,7 @@ image @IMAGE@img {
     }
 
     partition barebox-env {
+        image = "/dev/zero"
         fill = true
         in-partition-table = false
         offset = 512K
@@ -18,6 +19,7 @@ image @IMAGE@img {
     }
 
     partition barebox-state {
+        image = "/dev/zero"
         fill = true
         # We can not have the barebox partitions in the partition table right
         # now because:


### PR DESCRIPTION
This fixes failing builds caused by commit daccfdd ("meta-ptx: update to current master with genimage v17") in PR #117, which removed the image parameter for the barebox state and environment partition in the assumption that specifying the fill parameter instead would result in the partition being zeroed out.

This is not correct. genimage still needs an image name for the partition, but now it may have a length of zero because the rest of the partition (e.g. everything) will be filled with zeros.

This fixes these genimage build errors:

    | INFO: cmd: "rm -rf "…/build/tmp/work/lxatac-oe-linux-gnueabi/emmc-image/1.0/genimage-tmp"/*" (stderr):
    | INFO: android-sparse(emmc-image-lxatac-2024…15.simg): input image: emmc-image-lxatac-2024…15.img
    | ERROR: hdimage(emmc-image-lxatac-2024…15.img): no input file given
    | INFO: cmd: "rm -rf "…/build/tmp/work/lxatac-oe-linux-gnueabi/emmc-image/1.0/genimage-tmp"/*" (stderr):
    | WARNING: exit code 1 from a shell command.