### PR TITLE
meta-lxatac-software: tacd{,-webinterface}: update

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "e94c996e95fc215ef86deb1dd130205582eafeaa"
+SRCREV = "740ffaca3eb8560a556f7d942083928f290d8a19"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "e94c996e95fc215ef86deb1dd130205582eafeaa"
+SRCREV = "740ffaca3eb8560a556f7d942083928f290d8a19"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
This brings a couple of changes:

Web:

  - Labgrid configuration files are now rendered as text in the web interface to prevent syntax error warnings cause by the jinja templating inside these files.
  - Better inform users about which data is sent when polling for updates is enabled.

Daemon:

  - Only check for DUT power supply errors when the DUT power supply is on. This should solve errors where the TAC refuses to turn the power supply on when a noisy power supply is connected.
  - The on display on the device now shows a legend of which button does what and improve the help screen section about which button does what.
  - No longer fail when unknown keys are found tacds state file, e.g. after a downgrade.

TODO before merging:

  - [x] Test an image with the new tacd on actual hardware
        20240313 lgo: assigned to me until that is done.

This fixes #118.