### PR TITLE
barebox-tools/python3-labgrid: i.MX93 IMXUSBLoader compatibility

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools_2024.03.0.bb
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools_2024.03.0.bb
@@ -8,7 +8,7 @@ DEPENDS = "libusb1 libusb1-native lzop-native bison-native flex-native pkgconfig
 BBCLASSEXTEND = "native"
 
 SRC_URI = "http://barebox.org/download/barebox-${PV}.tar.bz2"
-SRC_URI[sha256sum] = "6a584d1fbb5d8ea6ce0c73d3a6c83ff531f488c64cbd6354d32fd420159539ed"
+SRC_URI[sha256sum] = "7dda8cc4e989d38162dc04d287a882edc828093f75baace9e40b2ab7902958ea"
 
 S = "${WORKDIR}/barebox-${PV}"
 

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/0001-resource-udev-add-new-USB-ID-for-IMXUSBLoader.patch
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/0001-resource-udev-add-new-USB-ID-for-IMXUSBLoader.patch
@@ -1,0 +1,26 @@
+From 5b98d86bf4424a81472469238b28aae9e490dce9 Mon Sep 17 00:00:00 2001
+From: Christian Hemp <c.hemp@phytec.de>
+Date: Wed, 21 Feb 2024 12:05:33 +0100
+Subject: [PATCH] resource: udev: add new USB ID for IMXUSBLoader
+
+Add USB ID for i.MX93 SoC to IMXUSBLoader.
+
+Upstream-Status: Accepted
+
+Signed-off-by: Christian Hemp <c.hemp@phytec.de>
+---
+ labgrid/resource/udev.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/labgrid/resource/udev.py b/labgrid/resource/udev.py
+index eaaed1a..00410d9 100644
+--- a/labgrid/resource/udev.py
++++ b/labgrid/resource/udev.py
+@@ -280,6 +280,7 @@ class IMXUSBLoader(USBResource):
+                          ("1fc9", "0128"), ("1fc9", "0126"),
+                          ("1fc9", "012b"), ("1fc9", "0134"),
+                          ("1fc9", "013e"), ("1fc9", "0146"),
++                         ("1fc9", "014e"),
+                          ("1b67", "4fff"), ("0525", "b4a4"), # SPL
+                          ("3016", "1001"),
+                          ]:

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
@@ -2,11 +2,11 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/python3-labgrid:"
 
 SRC_URI:remove = "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
 
-SRC_URI += " \
-    git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master \
-    file://userconfig.yaml \
-    file://labgrid.conf \
-"
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master \
+            file://userconfig.yaml \
+            file://labgrid.conf \
+            file://0001-resource-udev-add-new-USB-ID-for-IMXUSBLoader.patch \
+            "
 
 SRCREV = "3e1c0df0a3503d6f22e63a50ae45945ed12b69f8"
 


### PR DESCRIPTION
This PR is inspired by Issue #123.

It updates barebox-tools to the most recent release, so we get i.MX93 support in `imx-usb-loader` (which was added in v2023.12.0) and adds a patch to labgrid to add i.MX93 support as well.
The patch was taken from labgrid-project/labgrid#1331, which was already merged. The patch will thus only be required until the next labgrid upgrade.

Fixes #123.