### PR TITLE
meta-lxatac-software: tacd: update to version with Gen 3 support

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "740ffaca3eb8560a556f7d942083928f290d8a19"
+SRCREV = "e1e6ef55a8e2e9752c75e0a7debbfdb525eb1e70"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "740ffaca3eb8560a556f7d942083928f290d8a19"
+SRCREV = "e1e6ef55a8e2e9752c75e0a7debbfdb525eb1e70"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
There is a slight change in the ADC channel allocation in generation 3, that needs to be reflected in `tacd`.

TODO before merging:

- [x] Wait for the tacd PR to be merged linux-automation/tacd#66
- [x] Update SRC_URI and SRCREV
- [x] Test on hardware