### PR TITLE
lxatac-core-image-base: add lrzsz for x/y/zmodem support

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -72,6 +72,7 @@ IMAGE_INSTALL:append = "\
     linux-serial-test \
     lldpd \
     lmsensors \
+    lrzsz\
     lxatac-factory-data \
     lxatac-led-setup \
     lxatac-lldpd-config \


### PR DESCRIPTION
Xmodem is cumbersome enough as it is without having to forward it over TCP to remote hosts, which may not always work.

Therefore, include support for the lrzsz suite of tools, so users can ssh to the lxatac and run them locally if needed.

This has been tested by copying the resulting lsz binary to the lxatac and running
```
lsz -X -vv </dev/ttyUSB2 >/dev/ttyUSB2 fw_payload.bin.out
```