### PR TITLE
meta-lxatac-bsp: barebox: increase boot timeout when serial booting

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/.shellcheckrc
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/.shellcheckrc
@@ -1,0 +1,3 @@
+# Barebox scripts use variables defined outside of the script and they
+# assign values to variables with dots in their name.
+disable=SC2154,SC2276

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/init/20_serial_timeout.sh
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/init/20_serial_timeout.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "${bootsource}" = serial ]; then
+    global.autoboot_timeout=30
+fi

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/init/20_splash.sh
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/init/20_splash.sh
@@ -3,5 +3,4 @@
 # Turn the LCD on with a splash screen
 splash /env/data/splash.png
 
-# shellcheck disable=SC2276
 fb0.enable=1


### PR DESCRIPTION
When someone loads barebox via serial download instead of e.g. from the eMMC it is very likely that they want to upload an image via fastboot next and do not want to autoboot into linux right away.

Give them a bit more time to interrupt the boot process.

This PR is based on a discussion in PR https://github.com/linux-automation/meta-lxatac/pull/125#discussion_r1547540978.
There @a3f also brings up other points that concern the flashing guide in the README:

> AFAIK, the watchdog is only enabled before booting Linux (boot command), so wd -x directly after DFU bring-up doesn't matter for watchdogs. As for stopping the automatic boot process, fastboot flash has the same effect, see:
https://github.com/barebox/barebox/blob/5423885658da4beddec619c1ec4b1cb741c68554/common/fastboot.c#L814
>
> If this change fixes something, I suspect the issue is elsewhere.

TODO before merging:

- ~~[ ] Inverstigate what @a3f said about the effect of `wd -x` and change the README accordingly.~~
  The investigation is a separate topic from the change introduced here.