### PR TITLE
meta-lxatac-software: distro: tacos: update version to v24.04

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "23.11+dev"
+DISTRO_VERSION = "24.04"
 DISTRO_CODENAME = "tacos-nanbield"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
It's time to spin a new release. There is still some testing to do, but we can go into release candidate mode now and update the version number.

Changes since v23.11:

  - Update the yocto version from langdale to mickledore and from mickledore to nanbield.
  - Create a custom yocto distributiion (tacos) instead of using meta-ptx'es example distribution.
  - Statically assign UIDs / GIDs on the system at build time.
  - Enable the stable update channel by default when building new images (previously the devel channel was enabled by default).
  - The RAUC update hook now also migrates custom files via /etc/rauc/migrate.d/*.conf files.
  - Migrate /etc/hostname between RAUC installs.
  - Update the USB-SD-Mux control software to add support for the new USB-SD-Mux Fast.
  - Update the Linux Kernel to 6.8, Barebox to 2024.03 and TF-A to 2.9.
  - Update the tacd LXA TAC system daemon
    - Add web interface / local display notifications on USB port current overloads.
    - Add web interface / local display notifications on DUT Power failure. - Add error messages on the LCD if the tacd startup failed. - Fix an issue where the IPv4 address on the display would not always update. - The RGB LED is dimmed to match the brightness of the other LEDs. - Reboot notifications after an update should be less confusing if e.g. the other slot is bad or intentionally disabled. - The setup mode wizard was improved and simplified. - The setup mode asks for consent before polling for updates online. When updating from a version without consent support, update polling has to be enabled manually. - The stray "Your TAC is overheating" warning when the web interface loses the connection to the TAC was fixed. - The web interface no longer tries to highlight and lint the labgrid yaml files since the templating resulted in linting errors. - Users are informed better about the information that is shared with the Linux Automation GmbH when update polling is enabled. - Overcurrent/Overvoltage/Voltage inversion errors are no longer checked while the power switch is off. This prevents errors with some power supplies in some setups. - The on screen display now shows a legend of which button does what.
  - Add github-act-runner (an alternative runner for self hosted GitHub actions) and the official gitlab-runner. This allows scheduling CI jobs directly on the TAC.
  - Add the bcu utility to control some NXP eval boards.
  - Add the lrzsz utility for x/y/zmodem support.
  - Fix an issue where a TAC may come up with an unexpecteed MAC address on some boots.
  - Configure Barebox to only interrupt the boot when Ctrl+C is pressed. This should prevent issues where the boot is stopped e.g. due to noise on the RX line.
  - Add suport for LXA TAC Generation 3 devices