### PR TITLE
meta-lxatac-software: distro: tacos: enable creation of SPDX manifests

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -40,6 +40,9 @@ require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/security_flags.inc
 INHERIT += "uninative"
 
+# Enable creation of SPDX manifests
+INHERIT += "create-spdx"
+
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
 


### PR DESCRIPTION
This PR is inspired by a change suggested by @ejoerns in #137:

https://github.com/linux-automation/meta-lxatac/pull/137#pullrequestreview-2085690324

I don't know too well what it does, so maybe @ejoerns can come up with a more descriptive commit message ;).

TODO:

- [ ] ~~Come up with a more descriptive commit message~~