### PR TITLE
meta-lxatac-bsp: linux-lxatac: Build i2c-tiny-usb as module

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/defconfig
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/defconfig
@@ -2350,7 +2350,7 @@ CONFIG_I2C_STM32F7=y
 # CONFIG_I2C_CP2615 is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers


### PR DESCRIPTION
This module is needed for devices like the fisch.de "i2c-mp-usb" USB-to-I2C interface.