### PR TITLE
meta-lxatac-bsp/rauc: Enable event log

### DIFF
--- a/meta-lxatac-bsp/recipes-core/rauc/files/lxatac/system.conf
+++ b/meta-lxatac-bsp/recipes-core/rauc/files/lxatac/system.conf
@@ -22,3 +22,6 @@ resize=true
 [slot.bootloader.0]
 device=/dev/mmcblk1
 type=boot-emmc
+
+[log.all-log]
+filename=all-events.log


### PR DESCRIPTION
This enables rauc event logging for all types of events known to rauc. With this log we can examine boots, mark-good decisions after boot and a history of installed bundles.

The `all-events.log` file is created inside the data directory in `/srv/rauc/`.
There is no rotation configured for this file - so history is stored forever. This will add around 350 Bytes of log per boot and 900 Bytes of log per install.
Thus, for a reasonable use-case the log file should stay well below a few MB.