### PR TITLE
meta-lxatac-software: labgrid-exporter: Add migration notice to config

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/environment
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/environment
@@ -1,4 +1,9 @@
+# Changes to this file will be migrated during rauc installs.
+# Feel free to change this configuration if needed.
+
 # This is a 'portable' labgrid configuration.
 # Make sure that a host 'labgrid' can be resolved using your DNS searchlist.
+# Otherwise change it to your needds.
+
 LABGRID_COORDINATOR_IP=labgrid
 LABGRID_COORDINATOR_PORT=20408


### PR DESCRIPTION
The `/etc/labgrid-exporter/environment` is migrated during rauc install. So add a note informing the user that they are free to change it.

All other labgrid exporter config files already have a notice whether they are migrated or overridden. This file was the last one without such notice.