### PR TITLE
 ci: codespell: add spell checking CI job

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = npm-shrinkwrap.json,*.pem,*.patch
+ignore-words-list = crate,ratatui

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,16 @@
+name: codespell
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '10 21 * * 4'
+
+jobs:
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 -m pip install codespell
+      - run: codespell meta-lxatac-bsp meta-lxatac-software .github oe-init-build-env README.md

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Add `meta-lxatac` as git submodule and initialize _its_ submodules:
     $ git add .
     $ git commit -m "Initial commit"
 
-Re-use the sstate (build artifacts) from the previous build directory so we do
+Reuse the sstate (build artifacts) from the previous build directory so we do
 not have to re-build everything, and the download directory so we do not have
 to re-download when patching an already built package:
 
@@ -289,7 +289,7 @@ First we are going to generate new keys to sign bundles with:
     Country Name (2 letter code) [AU]:DE
     State or Province Name (full name) [Some-State]:
     Locality Name (eg, city) []:
-    Organization Name (eg, company) [Internet Widgits Pty Ltd]:Example Project
+    Organization Name (eg, company) [Internet Widgets Pty Ltd]:Example Project
     Organizational Unit Name (eg, section) []:
     Common Name (e.g. server FQDN or YOUR name) []:
     Email Address []:

--- a/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
+++ b/meta-lxatac-bsp/recipes-core/images/emmc-image/lxatac/genimage.config
@@ -25,7 +25,7 @@ image @IMAGE@img {
         # now because:
         #  - If we add them the partition label clashes with the label of the
         #    fixed partitions in the barebox devicetree.
-        #  - If we change the labels barebox still wont allow the partitions
+        #  - If we change the labels barebox still won't allow the partitions
         #    to overlap.
         #  - We have TACs in the wild that do not have the partitions,
         #    in the partition table so we can not just remove the fixed

--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -8,7 +8,7 @@ CERT_ENABLED_DIR="${RAUC_SLOT_MOUNT_POINT:?}/etc/rauc/certificates-enabled"
 BUNDLE_SPKI_HASHES="${RAUC_BUNDLE_SPKI_HASHES:?}"
 
 function enable_certificates () {
-	# Ignore the enabled certifcates from the bundle
+	# Ignore the enabled certificates from the bundle
 	rm "${CERT_ENABLED_DIR}"/*
 
 	for cert in "${CERT_AVAILABLE_DIR}"/*; do

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -136,7 +136,7 @@ IMAGE_INSTALL:append = "\
     zstd \
 "
 
-# is crun needed when using systemd unified hierarcy?
+# is crun needed when using systemd unified hierarchy?
 
 LICENSE = "MIT"
 

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
@@ -19,7 +19,7 @@ RDEPENDS:github-act-runner-dev:append = "make bash"
 
 SYSTEMD_SERVICE:${PN} = "github-act-runner.service"
 
-# This is required because the go build system fetches dependecies in the
+# This is required because the go build system fetches dependencies in the
 # compile stage.
 do_compile[network] = "1"
 

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
@@ -16,7 +16,7 @@ inherit systemd
 
 SYSTEMD_SERVICE:${PN} = "gitlab-runner.service"
 
-# This is required because the go build system fetches dependecies in the
+# This is required because the go build system fetches dependencies in the
 # compile stage.
 do_compile[network] = "1"
 

--- a/meta-lxatac-software/recipes-rust/bottom/bottom_0.9.6.bb
+++ b/meta-lxatac-software/recipes-rust/bottom/bottom_0.9.6.bb
@@ -13,7 +13,7 @@ CARGO_SRC_DIR = ""
 # The bottom Cargo.toml strips release builds, why makes it hard to debug.
 # Yocto has its own stripping feature, that preserves the debug symbols but
 # only installs the stripped version.
-# Pre-stripped binaries trgger a yocto QA error.
+# Pre-stripped binaries trigger a yocto QA error.
 CARGO_BUILD_FLAGS += "--config profile.release.strip=false"
 
 SRC_URI += " \


### PR DESCRIPTION
The `codespell` util allows catching typos with minimal false positives, because it uses a list of known common typos along with their correct spelling.

To limit the scope of this CI job to files we actually control, this excludes all external layers and all patch files via the `.codespellrc`.