### PR TITLE
meta-labgrid: use scarthgap branch instead of master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "meta-labgrid"]
 	path = meta-labgrid
 	url = https://github.com/labgrid-project/meta-labgrid.git
-	branch = master
+	branch = scarthgap
 [submodule "meta-virtualization"]
 	path = meta-virtualization
 	url = https://github.com/lgirdk/meta-virtualization.git


### PR DESCRIPTION
The tip of the master branch is no longer compatible with the scarthgap release, since it has the UNPACKDIR changes that are required for styhead. Since the scarthgap branch exists now and is up to date (it didn't initially, which is why this was set to "master") use that now.

This should solve the issue encountered by dependabot in #148.