### PR TITLE
meta-lxatac-bsp: arm-trusted-firmware-a: use git instead of tarball URL

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/arm-trusted-firmware-a/arm-trusted-firmware-a.inc
+++ b/meta-lxatac-bsp/recipes-bsp/arm-trusted-firmware-a/arm-trusted-firmware-a.inc
@@ -22,9 +22,9 @@ LIC_FILES_CHKSUM = "file://docs/license.rst;md5=713afe122abbe07f067f939ca3c480c5
 DEPENDS = "dtc-native"
 PROVIDES = "virtual/ARM-tf-a"
 
-SRC_URI = "https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot/${PV}.tar.gz"
+SRC_URI = "git://review.trustedfirmware.org/TF-A/trusted-firmware-a.git;protocol=https;branch=master"
 
-S = "${WORKDIR}/${PV}"
+S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 inherit deploy

--- a/meta-lxatac-bsp/recipes-bsp/arm-trusted-firmware-a/tf-a-stm32mp_2.9.bb
+++ b/meta-lxatac-bsp/recipes-bsp/arm-trusted-firmware-a/tf-a-stm32mp_2.9.bb
@@ -3,7 +3,7 @@ require arm-trusted-firmware-a.inc
 SUMMARY = "ARM Trusted Firmware-A for STM32MP1"
 LIC_FILES_CHKSUM = "file://docs/license.rst;md5=b2c740efedc159745b9b31f88ff03dde"
 
-SRC_URI[sha256sum] = "bca3d122ae4552677a77a70076bb229fa8b8c0358ab85ec964666bb386a9cf1b"
+SRCREV = "d3e71ead6ea5bc3555ac90a446efec84ef6c6122"
 
 
 COMPATIBLE_MACHINE = "lxatac"


### PR DESCRIPTION
Starting in at least late april 2024 (as indicated by [this thread][1] on the DistroKit mailing list) the old snapshot URL started responding with HTTP 401 Unauthorized errors.

Replace the tarball URL with a git URL on the same server.

[1]: https://lore.distrokit.org/distrokit/Zij_hXUXXHlJEagD@pengutronix.de/T/