### PR TITLE
CI: build: throw away the previous build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,9 @@ jobs:
           # Keeping the build directory gives us incremental builds,
           # with all its benefits (speed) and drawbacks (reproducibility).
 
-          # Make sure we start with a fresh config.
-          rm -rf build/conf
+          # Make sure we start with a fresh config and and without build
+          # artifacts other than the sstate.
+          rm -rf build/conf build/tmp
 
           # oe-init-build-env implicitly cd-s into the build directory.
           cd source
@@ -54,6 +55,10 @@ jobs:
             emmc-image \
             emmc-boot-image \
             tf-a-stm32mp
+
+          # Clean up before persisting the disk image,
+          # keeping only the downloads and sstate.
+          rm -rf build/conf build/tmp
       - name: Persist the disk image
         env:
           PERSISTENCE_TOKEN: ${{ secrets.PERSISTENCE_TOKEN }}


### PR DESCRIPTION
> [!NOTE]
> I am not convinced that this is a necessary or useful change.
> I would personally prefer keeping the CI job as is.
> This PR was mainly created to check what kind of impact such a change would have on the build time.

Keeping only the sstate an downloads between runs makes the result a bit more reproducible at the cost of having to do a bit more work per-run.