### PR TITLE
CI: distribution version: skip check for dependabot created branches

### DIFF
--- a/.github/workflows/distribution-version.yaml
+++ b/.github/workflows/distribution-version.yaml
@@ -8,7 +8,7 @@ jobs:
   check:
     name: consistency check
     runs-on: ubuntu-latest
-    if: github.repository == 'linux-automation/meta-lxatac'
+    if: github.repository == 'linux-automation/meta-lxatac' && !startsWith(github.ref, 'dependabot/')
     steps:
       - name: Install required packages
         run: |


### PR DESCRIPTION
When the distribution version check was written we only had branches in the upstream linux-automation/meta-lxatac repository that we considered production ready, hence why the test run for every branch.

Topic and WIP branches were kept in personal forks of the project and contributed using pull request (at which point this check should run).

Now dependabot also creates branches in linux-automation/meta-lxatac and by doing so generates CI job failures, because the distribution name does not match up with the branch name it uses.

See [this pull request checks overview](https://github.com/linux-automation/meta-lxatac/pull/155/checks) for an example failure.
The pull request check succeeded (because it uses the correct target branch) but the on: push check fails (as expected).

Filter out dependabot branches when running the distribution version consistency check.