### PR TITLE
meta-lxatac-software: distro: tacos: generate and install -lic packages

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -46,6 +46,7 @@ INHERIT += "create-spdx"
 # Create a directory for each package in `/usr/share/licenses`
 # and place licensing information there.
 LICENSE_CREATE_PACKAGE = "1"
+COPY_LIC_MANIFEST = "1"
 
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -43,6 +43,10 @@ INHERIT += "uninative"
 # Enable creation of SPDX manifests
 INHERIT += "create-spdx"
 
+# Create a directory for each package in `/usr/share/licenses`
+# and place licensing information there.
+LICENSE_CREATE_PACKAGE = "1"
+
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
 

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -2,7 +2,7 @@ SUMMARY = "LXA TAC image containing a selection of useful development tools"
 
 BAD_RECOMMENDATIONS = "rng-tools"
 
-IMAGE_FEATURES = "ssh-server-openssh empty-root-password tools-debug"
+IMAGE_FEATURES = "ssh-server-openssh empty-root-password tools-debug lic-pkgs"
 
 IMAGE_FSTYPES += "ext4"
 


### PR DESCRIPTION
Yocto provides two different ways to deploy software license files into the operating system image.
Either using `COPY_LIC_DIRS` and `COPY_LIC_MANIFEST` or using `LICENSE_CREATE_PACKAGE`.

According to the documentation the main difference is that `LICENSE_CREATE_PACKAGE` allows adding licenses for packages installed at runtime (e.g. using `opkg`).

But this is not why this commit uses `LICENSE_CREATE_PACKAGE` instead of the other method. This commit uses `LICENSE_CREATE_PACKAGE`, because it adds a license directory per package to `/usr/share/licenses`,
containing the original license files, instead of throwing everything into `/usr/share/common-licenses`.

This PR is developed in tandem with linux-automation/tacd#76, which serves the license files via the web interface.