### PR TITLE
CI: distribution version: fix skip check for dependabot created branches

### DIFF
--- a/.github/workflows/distribution-version.yaml
+++ b/.github/workflows/distribution-version.yaml
@@ -8,7 +8,7 @@ jobs:
   check:
     name: consistency check
     runs-on: ubuntu-latest
-    if: github.repository == 'linux-automation/meta-lxatac' && !startsWith(github.ref, 'dependabot/')
+    if: github.repository == 'linux-automation/meta-lxatac' && !startsWith(github.ref_name, 'dependabot/')
     steps:
       - name: Install required packages
         run: |


### PR DESCRIPTION
According [`github` context section][1] of the GitHub workflow documentation there are `github.ref` and `github.ref_name` with the difference being that the former is:

> The ref given is fully-formed, meaning that for branches the format is
> `refs/heads/<branch_name>`,
> for pull requests it is `refs/pull/<pr_number>/merge`,
> and for tags it is refs/tags/<tag_name>.
> For example, refs/heads/feature-branch-1.

While the latter is:

> The short ref name of the branch or tag that triggered the workflow run.
> This value matches the branch or tag name shown on GitHub.
> For example, feature-branch-1.
> For pull requests, the format is <pr_number>/merge.

The workflow file clearly assumes the latter format while using the former name, resulting in the check always being false.

The check itself also use `GITHUB_REF_NAME` and not `GITHUB_REF`.

[1]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#github-context

Fixes: #160 