### PR TITLE
ci: build: print log files of failed tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,24 @@ jobs:
             emmc-image \
             emmc-boot-image \
             tf-a-stm32mp
+      - name: Print logs of failed jobs
+        if: ${{ failure() }}
+        shell: python3 {0}
+        run: |
+          import os
+
+          PREFIX = 'ERROR: Logfile of failure stored in:'
+
+          for ln in open('build/tmp/log/cooker/lxatac/console-latest.log'):
+              if not ln.startswith(PREFIX):
+                continue
+
+              path = ln.removeprefix(PREFIX).strip()
+              shorter_path = path.removeprefix(os.getcwd()).strip('/')
+
+              print(f'::group::Contents of "{shorter_path}"')
+              print(open(path).read())
+              print('::endgroup::')
       - name: Persist the disk image
         env:
           PERSISTENCE_TOKEN: ${{ secrets.PERSISTENCE_TOKEN }}


### PR DESCRIPTION
It is quite inconvenient to not see the logs of failed tasks for the GitHub CI builds.
This adds a step that parses the last build log and cats all log files so they appear in the web interface.

See [this run](https://github.com/linux-automation/meta-lxatac/actions/runs/10473792423/job/29006469444?pr=168) for an example of the print step in action.