### PR TITLE
ci: build: only persist disk images for protected branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Persist the disk image
         env:
           PERSISTENCE_TOKEN: ${{ secrets.PERSISTENCE_TOKEN }}
-        if: ${{ env.PERSISTENCE_TOKEN != ''  }}
+        if: ${{ github.ref_protected && env.PERSISTENCE_TOKEN != '' }}
         run: |
           sudo fstrim /
           echo "$PERSISTENCE_TOKEN" > ~/config/persist


### PR DESCRIPTION
Right now this mostly means not persisting runs that are on the `dependabot/…` branches but _not_ triggered by dependabot.

- This does not affect jobs triggered _by_ dependabot, because they always [behave like pull requests from a forked repository](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).
- This affects `dependabot/…` branches even if there is a `*` branch protection rule configured for the repository, because

  >  Because GitHub uses the File::FNM_PATHNAME flag for the File.fnmatch syntax, the * wildcard does not match directory separators (/). For example, qa/* will match all branches beginning with qa/ and containing a single slash, but will not match qa/foo/bar.

  [Source](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#about-branch-protection-rules)