### PR TITLE
meta-lxatac-software: tacd{,-webinterface}: fix broken /etc/motd update

### DIFF
--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -3,7 +3,7 @@ inherit cargo
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "a519eb3181516ac73fa7cc7cb7aa9cccd2b2f9c0"
+SRCREV = "e79b017da65f4a084a8b24f1118e15b0c3f25ae8"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "a519eb3181516ac73fa7cc7cb7aa9cccd2b2f9c0"
+SRCREV = "e79b017da65f4a084a8b24f1118e15b0c3f25ae8"
 
 S = "${WORKDIR}/git/web"
 


### PR DESCRIPTION
The previous tacd version failed to bind-mount the volatile motd in `/var/run/tacd` to `/etc/motd` and did not generate an up to date motd due to that.