### PR TITLE
meta-lxatac-software: distro: tacos: update version to v24.09

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "24.04+dev"
+DISTRO_VERSION = "24.09"
 DISTRO_CODENAME = "tacos-scarthgap"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
It's time to spin a new release.

Changes since v24.04:

  - Update yocto version from nanbield to scarthgap.
  - Update Linux Kernel from 6.8 to 6.10.
  - Update bottom, github-act-runner, gitlab-runner, ripgrep, imx-uuu, lxa-iobus, usbsdmux, rauc.
  - Include license information in the generated images and bundles and display them on the web interface.
  - Update the system management daemon and web interface (tacd) with the following new features:
    - Retry polling for update bundles with exponential backoff. This solves a problem where the first update poll after bootup is likely to fail, because the network is not yet up, and the next one only takes place hours or days later.
    - A diagnostics screen that displays a lot of information on a single screen and provides a border that can be used to align the LCD. It also allows toggling the LEDs and backlight to make sure they work correctly. - Notifications in the web interface that redirect the user to appropriate command lines when they try to change the active RAUC slot or enable/disable update channels in the web interface. - A /etc/motd that is updated in realtime with relevant information about the TAC. - A web view of the software packages and licenses that make up the meta-lxatac image.