### PR TITLE
meta-lxatac-software: distro: tacos: start v24.09 devel phase

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "24.09"
+DISTRO_VERSION = "24.09+dev"
 DISTRO_CODENAME = "tacos-scarthgap"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
Now that we have a v24.09 stable release we need to start denoting everything based on it as +dev again.

TODO before merging:

- [x] Merge #178 first.
- [x] Tag the 24.09 release
- [x] Upload release images and bundles.