### PR TITLE
meta-lxatac-software: python3-labgrid: upgrade to version using grpc

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-grpcio-channelz_1.62.2.bb
+++ b/meta-lxatac-software/recipes-devtools/python/python3-grpcio-channelz_1.62.2.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Google gRPC channelz"
+HOMEPAGE = "http://www.grpc.io/"
+SECTION = "devel/python"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515"
+
+inherit pypi setuptools3
+
+DEPENDS += "python3-grpcio"
+
+SRC_URI[sha256sum] = "6e4ac2c43d76b245c5f66d98f523db08786b186128a655ee6f20a30a7e68e4f9"
+
+RDEPENDS:${PN} = "python3-grpcio"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-lxatac-software/recipes-devtools/python/python3-grpcio-reflection_1.62.2.bb
+++ b/meta-lxatac-software/recipes-devtools/python/python3-grpcio-reflection_1.62.2.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Google gRPC reflection"
+HOMEPAGE = "http://www.grpc.io/"
+SECTION = "devel/python"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515"
+
+inherit pypi setuptools3
+
+DEPENDS += "python3-grpcio"
+
+SRC_URI[sha256sum] = "2dd44806d68d0006636529bda573012b19a42281478c2d051cdaaebb91e2516c"
+
+RDEPENDS:${PN} = "python3-grpcio"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Labgrid Exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment="PYTHONUNBUFFERED=1"
+EnvironmentFile=/etc/labgrid/environment
+ExecStart=/usr/bin/labgrid-exporter --coordinator ${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT} /etc/labgrid/configuration.yaml
+Restart=on-failure
+RestartForceExitStatus=100
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
@@ -4,7 +4,14 @@ SRC_URI += "file://userconfig.yaml \
             file://labgrid.conf \
             "
 
-SRCREV = "e5ace1a36c4e552b950cf356ce0e34586f776432"
+SRCREV = "6b541210c6063e97d81e257d2d6bda1444d9ec78"
+
+RDEPENDS:${PN} += " \
+    python3-grpcio \
+    python3-grpcio-reflection \
+    python3-grpcio-channelz \
+"
+RDEPENDS:${PN}:remove = "python3-autobahn"
 
 do_install:append() {
     # The userconfig.yaml is migrated via rauc hook between installs.


### PR DESCRIPTION
This marks a breaking change compared to the previous release version, as master now uses grpc instead of crossbar to communicate between the client, coordinator and exporters.

This means all of these components need to be updated to the grpc-based versions at the same time.

See https://github.com/labgrid-project/labgrid/pull/1469 for more information about this change.

Once we have tested these changes in meta-lxatac they should be moved to [meta-labgrid](https://github.com/labgrid-project/meta-labgrid/).

TODO before merging:

- [ ] Get Signed-Off-By's from @jluebbe since these changes were initially authored by him on an internal meta-lxatac customization layer.
- [x] Make sure the exporter works with other grpc based coordinators.