### PR TITLE
ci: build: enable artifact upload to the local Forrest runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,10 +75,18 @@ jobs:
           rsync -rvx --ignore-existing build/downloads yocto-cache: || true
           rsync -rvx --ignore-existing build/sstate-cache yocto-cache: || true
 
-      - name: Upload RAUC Bundle
+      - name: Upload Artifacts to the Forrest Runner
+        uses: forrest-runner/upload-artifact@main
+        with:
+          path: |
+            images/tf-a-stm32mp153c-lxa-tac.stm32
+            images/emmc-boot-image-lxatac.fip
+            images/emmc-boot-image-lxatac.img
+            images/emmc-image-lxatac.simg
+            images/lxatac-core-bundle-base-lxatac.raucb
+
+      - name: Upload Artifact links to GitHub
         uses: actions/upload-artifact@v4
         with:
-          name: rauc-bundle
-          path: images/lxatac-core-bundle-base-lxatac-*.raucb
-          compression-level: 0
-          retention-days: 30
+          name: images
+          path: images/*.desktop


### PR DESCRIPTION
This makes it so that artifacts are no longer uploaded via the internet to GitHub's cloud infrastructure but instead stay on the physical server the builds run on.

Since the built images will mostly be consumed from within the building the server is located in this should reduce the upload bandwidth used, allowing us to also upload the eMMC image and not only the RAUC bundle.

Since the uploaded files are served from a webserver as-is, instead of being packaged in a zip file like "normal" artifacts are, they can also be used in a `rauc install` call directly, making testing of a build much easier.

The artifact file that _is_ uploaded to GitHub's infrastructure contains `.desktop` files with `Link=https://...` entries withing them that point to the location of the actual file.