### PR TITLE
meta-lxatac-software: python3-labgrid: use SRCREV from meta-labgrid

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
@@ -4,8 +4,6 @@ SRC_URI += "file://userconfig.yaml \
             file://labgrid.conf \
             "
 
-SRCREV = "e5ace1a36c4e552b950cf356ce0e34586f776432"
-
 do_install:append() {
     # The userconfig.yaml is migrated via rauc hook between installs.
     # Deploy a copy of the file so that users can go back to a default config


### PR DESCRIPTION
PR https://github.com/linux-automation/meta-lxatac/pull/195 should have updated the labgrid version used to the one configured in meta-labgrid.
Instead it only updated the recipe (and dropped the dependency for autobahn etc.), so we currently have a labgrid version installed that still depends on autobahn, but with dependencies for a grpc based labgrid version.

This results in `labgrid-exporter.service` failing to start:

    Traceback (most recent call last):
      File "/usr/bin/labgrid-exporter", line 5, in <module>
        from labgrid.remote.exporter import main
      File "/usr/lib/python3.12/site-packages/labgrid/remote/exporter.py", line 19, in <module>
        from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
    ModuleNotFoundError: No module named 'autobahn'

Fix that by _actually_ using the SRCREV from meta-labgrid.