### PR TITLE
meta-lxatac-software: tinyxml2: remove recipe

### DIFF
--- a/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.182.bb
+++ b/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.182.bb
@@ -12,6 +12,6 @@ inherit cmake pkgconfig
 
 S = "${WORKDIR}/uuu-uuu_${PV}"
 
-DEPENDS = "libusb zlib bzip2 openssl tinyxml2"
+DEPENDS = "libusb zlib bzip2 openssl libtinyxml2"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/meta-lxatac-software/recipes-support/tinyxml2/tinyxml2_10.0.0.bb
+++ b/meta-lxatac-software/recipes-support/tinyxml2/tinyxml2_10.0.0.bb
@@ -1,9 +1,0 @@
-LICENSE = "Zlib"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=135624eef03e1f1101b9ba9ac9b5fffd"
-
-SRC_URI += "git://github.com/leethomason/tinyxml2.git;protocol=https;branch=master"
-SRCREV = "321ea883b7190d4e85cae5512a12e5eaa8f8731f"
-
-S = "${WORKDIR}/git"
-
-inherit cmake


### PR DESCRIPTION
I've noticed that we can remove our local `tinyxml2` recipe because `libtinyxml2` is already in meta-oe (and has been for a long time. Not sure why I did not notice back then).

This came up while investigation whether we should upsteam the `imx-uuu` package somewhere.
There is however already a [`uuu` recipe in `meta-freescale`](https://git.yoctoproject.org/meta-freescale/tree/recipes-devtools/uuu), so I guess the answer is no.
Adding the `meta-freescale` layer just for this recipe does not seem like a sensible thing to do either, so I guess things will stay as they are.