### PR TITLE
meta-lxatac-software: bcu: prepare for upstreaming

### DIFF
--- a/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.100.bb
+++ b/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.100.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=884d48c2aa7b82e1ad4a33909fab24b6"
 SRC_URI = "git://github.com/nxp-imx/bcu;protocol=https;branch=master \
            file://0001-CMakeLists-do-not-use-vendored-libcurl.patch \
            "
-SRCREV = "04fecca3706896820c0119538c7545cbe52e85ed"
+SRCREV = "c34d89b29f3d0d12793cd78b194d2f1d11728baf"
 
 S = "${WORKDIR}/git"
 

--- a/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.92.bb
+++ b/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.92.bb
@@ -20,3 +20,4 @@ DEPENDS = "curl libyaml libusb1 openssl libftdi"
 
 inherit cmake pkgconfig
 
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.92.bb
+++ b/meta-lxatac-software/recipes-devtools/bcu/bcu_1.1.92.bb
@@ -1,4 +1,11 @@
-SUMMARY = "Board Remote Control Utilities"
+SUMMARY = "NXP Board Control Utilities"
+DESCRIPTION = "The NXP Board Control Utilities are able to control various \
+               features of NXP i.MX evaluation boards (EVK) from a host \
+               computer. \
+               Features like resetting the board, selecting the boot mode, \
+               monitoring power consumption, programming the EEPROM and others"
+HOMEPAGE = "https://github.com/nxp-imx/bcu"
+SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=884d48c2aa7b82e1ad4a33909fab24b6"
 


### PR DESCRIPTION
According to the [OpenEmbedded Layer Index](https://layers.openembedded.org/layerindex/) there is not yet an upstream [`bcu`](https://github.com/nxp-imx/bcu) recipe.
This means we should at least attempt to upstream it to e.g. `meta-openembedded`.

Do some cleanup, updating and improvements first.

Feel free to be extra strict with your review, so people do not have a reason to be mean to me on the mailing list later.