### PR TITLE
meta-lxatac-bsp: linux-lxatac: add aliases for can/i2c/spi and disable rtc

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0103-ARM-dts-stm32-lxa-tac-extend-the-alias-table.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0103-ARM-dts-stm32-lxa-tac-extend-the-alias-table.patch
@@ -1,0 +1,43 @@
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Mon, 11 Nov 2024 09:03:11 +0100
+Subject: [PATCH] ARM: dts: stm32: lxa-tac: extend the alias table
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some of the userspace software and tests depend on the can/i2c/spi devices
+having the same name on every boot.
+This may not always be the case based on e.g. parallel probe order.
+
+Assign static device numbers to all can/i2c/spi devices.
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+index ca94a1e0ff66..a8d249bdeece 100644
+--- a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
++++ b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+@@ -16,12 +16,20 @@
+ 
+ / {
+ 	aliases {
++		can0 = &m_can1;
++		can1 = &m_can2;
+ 		ethernet0 = &ethernet0;
+ 		ethernet1 = &port_uplink;
+ 		ethernet2 = &port_dut;
++		i2c0 = &i2c1;
++		i2c1 = &i2c4;
++		i2c2 = &i2c5;
+ 		mmc1 = &sdmmc2;
+ 		serial0 = &uart4;
+ 		serial1 = &usart3;
++		spi0 = &spi2;
++		spi1 = &spi4;
++		spi2 = &spi5;
+ 	};
+ 
+ 	chosen {

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0104-ARM-dts-stm32-lxa-tac-disable-the-real-time-clock.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0104-ARM-dts-stm32-lxa-tac-disable-the-real-time-clock.patch
@@ -1,0 +1,34 @@
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Mon, 11 Nov 2024 09:08:49 +0100
+Subject: [PATCH] ARM: dts: stm32: lxa-tac: disable the real time clock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The RTC was enabled under the false assumption that the SoM already
+contains a suitable 32.768 kHz crystal.
+It does however not contain such a crystal and since none is fitted
+externally to the SoM the RTC can not be used on the hardware.
+
+Reflect that in the devicetree.
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+index a8d249bdeece..055235d0838e 100644
+--- a/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
++++ b/arch/arm/boot/dts/st/stm32mp15xc-lxa-tac.dtsi
+@@ -311,10 +311,6 @@ regulators {
+ 	};
+ };
+ 
+-&rtc {
+-	status = "okay";
+-};
+-
+ &sdmmc2 {
+ 	pinctrl-names = "default", "opendrain", "sleep";
+ 	pinctrl-0 = <&sdmmc2_b4_pins_a &sdmmc2_d47_pins_b>;

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0201-Release-6.11-customers-lxa-lxatac-20241111-1.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0201-Release-6.11-customers-lxa-lxatac-20241111-1.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Tue, 17 Sep 2024 15:09:19 +0200
-Subject: [PATCH] Release 6.11/customers/lxa/lxatac/20240917-1
+Date: Mon, 11 Nov 2024 09:36:12 +0100
+Subject: [PATCH] Release 6.11/customers/lxa/lxatac/20241111-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 34bd1d5f9672..af51b53e437d 100644
+index 34bd1d5f9672..b4fe2250a874 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 34bd1d5f9672..af51b53e437d 100644
  PATCHLEVEL = 11
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20240917-1
++EXTRAVERSION =-20241111-1
  NAME = Baby Opossum Posse
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
@@ -1,6 +1,6 @@
 # umpf-base: v6.11
 # umpf-name: 6.11/customers/lxa/lxatac
-# umpf-version: 6.11/customers/lxa/lxatac/20240917-1
+# umpf-version: 6.11/customers/lxa/lxatac/20241111-1
 # umpf-topic: v6.11/topic/reproducible-build
 # umpf-hashinfo: d6ed6f191343a77bfe41d7436b51dffe8bcac441
 # umpf-topic-range: 98f7e32f20d28ec452afb208f9cffc08448a2652..1b888dc7203b47ea21aacbf471cd762f82f36678
@@ -8,19 +8,21 @@ SRC_URI += "\
   file://patches/0001-ARM-Don-t-mention-the-full-path-of-the-source-direct.patch \
   "
 # umpf-topic: v6.8/customers/lxa/lxatac
-# umpf-hashinfo: b7d99b8a22130c95b0c6d25d6fb0d4f72bf8322e
-# umpf-topic-range: 1b888dc7203b47ea21aacbf471cd762f82f36678..bb492c850a1e92262b1eece4113fb09a92c0ff1d
+# umpf-hashinfo: 41e4da0d7f6a4d2ddef615f2d69fc7d6298e737e
+# umpf-topic-range: 1b888dc7203b47ea21aacbf471cd762f82f36678..e3e86afd5e87a3c0d3a0441c0243709432a15d67
 SRC_URI += "\
   file://patches/0101-ARM-dts-stm32-lxa-tac-adjust-USB-gadget-fifo-sizes-f.patch \
   file://patches/0102-ARM-dts-stm32-lxa-tac-Add-support-for-generation-3-d.patch \
+  file://patches/0103-ARM-dts-stm32-lxa-tac-extend-the-alias-table.patch \
+  file://patches/0104-ARM-dts-stm32-lxa-tac-disable-the-real-time-clock.patch \
   "
-# umpf-release: 6.11/customers/lxa/lxatac/20240917-1
-# umpf-topic-range: bb492c850a1e92262b1eece4113fb09a92c0ff1d..0c61d3807b291bd09fc8550b4be0ba00a0c73321
+# umpf-release: 6.11/customers/lxa/lxatac/20241111-1
+# umpf-topic-range: e3e86afd5e87a3c0d3a0441c0243709432a15d67..2641aafd3302692a20766af9722f17503b9c9d2a
 SRC_URI += "\
-  file://patches/0201-Release-6.11-customers-lxa-lxatac-20240917-1.patch \
+  file://patches/0201-Release-6.11-customers-lxa-lxatac-20241111-1.patch \
   "
 UMPF_BASE = "6.11"
-UMPF_VERSION = "20240917-1"
+UMPF_VERSION = "20241111-1"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 LINUX_VERSION = "${UMPF_BASE}"
 # umpf-end


### PR DESCRIPTION
The aliases ensure a stable numbering of the can / i2c / spi devices. This solves an issue we have started to observe with Linux 6.11, where the SPI bus numbers have changed/are no longer stable between boots.

The other change is disabling the RTC node, since it could not be used anyways because the RTC is missing a 32.768 kHz clock crystal.

- [x] Test on hardware and check if the SPI bus numbers match the ~~old~~ new ones in:<br/> https://github.com/linux-automation/labgrid-lxatac/pull/4