### PR TITLE
meta-lxatac-software: distro: tacos: configure VOLATILE_LOG_DIR in distro

### DIFF
--- a/meta-lxatac-bsp/conf/machine/lxatac.conf
+++ b/meta-lxatac-bsp/conf/machine/lxatac.conf
@@ -35,8 +35,4 @@ KERNEL_DEVICETREE = "\
 # The FIT image is stored in a separate partition
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-modules"
 
-# Don't symlink /var/log to /var/log/volatile as we do actually want
-# persistent logging.
-VOLATILE_LOG_DIR = "no"
-
 MACHINE_FEATURES = "serial ext2 rtc usbhost usbgadget"

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -40,6 +40,10 @@ USERADD_ERROR_DYNAMIC = "error"
 USERADD_UID_TABLES = "files/passwd"
 USERADD_GID_TABLES = "files/group"
 
+# Don't symlink /var/log to /var/log/volatile as we do actually want
+# persistent logging.
+VOLATILE_LOG_DIR = "no"
+
 # do not include libc variant name in tmp directory
 TCLIBCAPPEND = ""
 


### PR DESCRIPTION
Our preference for storing log files in a persistent location is not really machine/hardware specific but more of a distribution/software decision.