### PR TITLE
meta-lxatac-software: distro: tacos: make /srv on the rootfs read-only

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -40,6 +40,10 @@ USERADD_ERROR_DYNAMIC = "error"
 USERADD_UID_TABLES = "files/passwd"
 USERADD_GID_TABLES = "files/group"
 
+# Reduce read/write/directory permissions for /srv to indicate that it should
+# only be used as a mount point and that no files should be written there.
+FILESYSTEM_PERMS_TABLES += "files/fs-perms-srv-ro.txt"
+
 # Don't symlink /var/log to /var/log/volatile as we do actually want
 # persistent logging.
 VOLATILE_LOG_DIR = "no"

--- a/meta-lxatac-software/files/fs-perms-srv-ro.txt
+++ b/meta-lxatac-software/files/fs-perms-srv-ro.txt
@@ -1,0 +1,6 @@
+# This matches the original fs-perms.txt.
+# The only difference is that permissions were restricted (0755 -> 0500)
+# since the directory should only be used as a mount point.
+# This will however not stop processes running as root from writing to the
+# directory due to CAP_DAC_OVERRIDE.
+/srv				0500	root	root	false - - -


### PR DESCRIPTION
We do not want any service to write to `/srv` (in the root filesystem) before the `/srv` partition is set up and mounted.
Because if `/srv` is not empty `systemd-gpt-auto-generator` will not generate a mount unit for it.

Every now and then however some service changes and writes to `/srv/` before the partition is set up by the first boot.
Most recently podman (see https://github.com/linux-automation/meta-lxatac/pull/206 for the fix).

This is why we have added the following to the task that lead to tracking down https://github.com/linux-automation/meta-lxatac/pull/206:

> 050.600 First boot somtimes writes to /srv
> …
> [ ] lgo: Mark /srv as not-writeable in the root-fs, so that it can only be written once the /srv-partition has been mounted.

This PR implements that.

---

TODO before merging:

- [x] Make sure the permissions are actually applied