### PR TITLE
labgrid-exporter: add RKUSBLoader match to template

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -71,6 +71,9 @@ lxatac-usb-ports-p{{idx}}:
   IMXUSBLoader:
     match:
       'ID_PATH': '{{sysfs}}'
+  RKUSBLoader:
+    match:
+      'ID_PATH': '{{sysfs}}'
   LXAUSBMux:
     match:
       '@ID_PATH': '{{sysfs}}'


### PR DESCRIPTION
RKUSBLoader is the resource associated with Rockchip SoCs that fall through to BootROM mode, when no other bootable media is found.

Add it to the resource list, so the Labgrid exporter running on the LXA TAC can announce suitable resources when they exist.

Note that this on its own is not sufficient: RKUSBDriver, which will operate on RKUSBLoader expects rkdeveloptool to be installed. This is available in the Debian repositories, but we don't have a bitbake recipe for that yet.

What we do have is rk-usb-loader, which is the RK35xx-loader bundled with barebox. This supports only the SoCs supported by barebox, has different arguments than rkdeveloptool and is not supported by Labgrid at all. The fact that the default tool expected by RKUSBDriver is named rk-usb-loader is a quite unfortunate accident...