### PR TITLE
meta-lxatac-software: containers: pass through /var/cache/labgrid

### DIFF
--- a/meta-lxatac-software/recipes-devtools/containers/files/container-start.sh
+++ b/meta-lxatac-software/recipes-devtools/containers/files/container-start.sh
@@ -9,7 +9,9 @@ else
         echo "INFO: No Debian container present. Starting a new one using Podman."
         echo "ATTENTION: Container installation might require Internet access and correct system time!"
         hostname="$(hostname)"
-        podman run -it --name=debian --hostname "${hostname}-debian" --privileged --network=host --volume=/home/:/home/ --volume=/srv/:/srv/ debian
+        podman run -it --name=debian --hostname "${hostname}-debian" --privileged --network=host \
+		--volume=/home/:/home/ --volume=/srv/:/srv/ --volume=/var/cache/labgrid/:/var/cache/labgrid/ \
+		debian
 
 	podmanerr=$?
 


### PR DESCRIPTION
Labgrid's `ManagedFile` class handles synchronisation of files to remote hosts.
When a path is not accessible on the TAC, it will be transferred into
`/var/cache/labgrid` and then that path is passed to locally installed tools.

To allow transparently using these paths from within a container, add it
to the volumes passed through when running container-start.

This was tested as follows:

  - On the development host, create `rkdeveloptool-rk3399pro.yaml` with:
```
    targets:
      main:
        resources:
          RemotePlace:
            name: !template '$LG_PLACE'
        drivers:
          RKUSBDriver:
            usb_loader: usb_loader
    tools:
      rk-usb-loader: /bin/rkdeveloptool
    images:
      usb_loader: /home/a3f/Downloads/rk3399pro_loader_v1.20.115.bin
```
  - On the TAC, install `rkdeveloptool` inside the Debian container

  - On the TAC, add `/bin/rkdeveloptool` with:
```
    #!/bin/sh

    podman start debian >/dev/null
    podman exec debian rkdeveloptool "$@"
    podman stop -i -t 0 debian >/dev/null
```
  - On the TAC, add into Labgrid System config for each USB port:
```
    RKUSBLoader:
      match:
        'ID_PATH': '{{sysfs}}'
```
This allowed using of labgrid-client bootstrap to call rkdeveloptool on
the remote target without having to have a recipe for rkdeveloptool.