### PR TITLE
CI: add support for stable branches and minor versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - scarthgap
+      - stable-*
   push:
     branches:
       - scarthgap
+      - stable-*
   schedule:
     - cron: '10 21 * * 4'
 

--- a/.github/workflows/distribution-version.py
+++ b/.github/workflows/distribution-version.py
@@ -77,12 +77,11 @@ def check_codename(codename):
     ref = os.environ.get("GITHUB_REF_NAME")
     ref_type = os.environ.get("GITHUB_REF_TYPE")
 
-    if base_ref:
-        print(f"Checking codename {codename} against pull request into {base_ref}")
-        assert codename == f"tacos-{base_ref}"
-    elif ref and ref_type == "branch":
-        print(f"Checking codename {codename} against branch {ref}")
-        assert codename == f"tacos-{ref}"
+    branch = base_ref or (ref if ref_type == "branch" else None)
+
+    if branch:
+        print(f"Checking codename {codename} against branch {branch}")
+        assert codename == f"tacos-{branch}"
     elif ref_type == "tag":
         print("Running for a tag. Skipping codename check")
     else:

--- a/.github/workflows/distribution-version.py
+++ b/.github/workflows/distribution-version.py
@@ -79,7 +79,9 @@ def check_codename(codename):
 
     branch = base_ref or (ref if ref_type == "branch" else None)
 
-    if branch:
+    if branch and branch.startswith("stable-"):
+        print("Running for a stable branch. Skipping codename check")
+    elif branch:
         print(f"Checking codename {codename} against branch {branch}")
         assert codename == f"tacos-{branch}"
     elif ref_type == "tag":

--- a/.github/workflows/distribution-version.py
+++ b/.github/workflows/distribution-version.py
@@ -54,15 +54,15 @@ def check_version(distro_version):
         assert version_bb["dev"] == ""
         assert version_tag_numeric == version_bb_numeric
 
-    elif version_bb["dev"] == "":
-        # Release candidates already have the next release version set,
-        # but it must be newer than any tag in the current commit's history.
-        assert version_bb_numeric > version_tag_numeric
-
-    else:
+    elif version_bb["dev"]:
         # Non release candidate versions should have the previous tagged
         # version number plus the +dev suffix set.
         assert version_bb_numeric == version_tag_numeric
+
+    else:
+        # Release candidates already have the next release version set,
+        # but it must be newer than any tag in the current commit's history.
+        assert version_bb_numeric > version_tag_numeric
 
 
 def check_codename(codename):


### PR DESCRIPTION
Due to issue #203 we will need to release a v24.09.1 version of tacos.

For that we will want to create a stable-24.09 branch based on 6204945f502834569d769daf071cc83606897dce (the commit tagged as v24.09) add the required fixes and tag v24.09.1 based on it.

This is however not yet supported in our CI scripts.

Change that.