### PR TITLE
stable-24.09: meta-lxatac-software: python3-labgrid: use release v24.0.2

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "24.09"
+DISTRO_VERSION = "24.09.1"
 DISTRO_CODENAME = "tacos-scarthgap"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_git.bbappend
@@ -4,7 +4,8 @@ SRC_URI += "file://userconfig.yaml \
             file://labgrid.conf \
             "
 
-SRCREV = "e5ace1a36c4e552b950cf356ce0e34586f776432"
+SRCREV = "08b1cfbfb1ee6afd8996ddeef4a9b1b6fd058ee7"
+SRCBRANCH = "stable-24.0"
 
 do_install:append() {
     # The userconfig.yaml is migrated via rauc hook between installs.


### PR DESCRIPTION
… instead of some more or less random master commit.

The previous labgrid commit, when used with the `ser2net` version on the TAC results in the following error when trying to connect to a console via labgrid:

> Invalid accepter port name/number 'telnet(rfc2217,mode=server),48431':
> Invalid data to parameter

This is because the rootfs contains `ser2net` 4.6.1, which requires, for our purposes, that the command line contains `,tcp`.

But the labgrid commit installed on the target does not add this argument.

Update the commit hash to the one for the v24.0.2 release.

This is fixed in the scarthgap branch by commit https://github.com/linux-automation/meta-lxatac/commit/6876eb8df82666fff91293d6b943ff764d13fbf9 ("meta-lxatac-software: python3-labgrid: use SRCREV from meta-labgrid")
which removes the `SRCREV` line altogether and instead uses the labgrid version from meta-labgrid.

This fixes #203.

---

TODO before merging:

- [x] The `stable-24.09` branch includes commits from PR #211. It should be reviewed first.