### PR TITLE
meta-lxatac-software: rkdeveloptool: Add recipe for version 1.32

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -106,6 +106,7 @@ IMAGE_INSTALL:append = "\
     python3-venv \
     rauc \
     ripgrep \
+    rkdeveloptool \
     rsync \
     screen \
     ser2net \

--- a/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool/0001-Makefile-disable-format-truncation-errors.patch
+++ b/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool/0001-Makefile-disable-format-truncation-errors.patch
@@ -1,0 +1,29 @@
+From 99795f8cc8137fef62ca72707df972bf7c787027 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
+Date: Tue, 12 Nov 2024 11:32:52 +0100
+Subject: [PATCH] Makefile: disable format-truncation errors
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The build fails with current compilers due to format-truncation errors.
+Ignore them for now.
+
+Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 1b6385d..81aebf6 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -3,7 +3,7 @@
+ SUBDIRS =
+ DIST_SUBDIRS = cfg
+ 
+-AM_CPPFLAGS = -Wall -Werror -Wextra -Wreturn-type -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE $(LIBUSB1_CFLAGS)
++AM_CPPFLAGS = -Wall -Werror -Wno-format-truncation -Wextra -Wreturn-type -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE $(LIBUSB1_CFLAGS)
+ 
+ bin_PROGRAMS = rkdeveloptool
+ rkdeveloptool_SOURCES = main.cpp \

--- a/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool_1.32.bb
+++ b/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool_1.32.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Rockchip Development Tool"
+DESCRIPTION = "Communicate with the Rockchip Boot ROM to upload new software \
+               read/write to memory locations and reset the device."
+HOMEPAGE = "https://github.com/rockchip-linux/rkdeveloptool"
+SECTION = "devel"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://license.txt;md5=ea9445d9cc03d508cf6bb769d15a54ef"
+
+SRC_URI = "git://github.com/rockchip-linux/rkdeveloptool.git;protocol=https;branch=master \
+           file://0001-Makefile-disable-format-truncation-errors.patch \
+           "
+
+SRCREV = "46bb4c073624226c3f05b37b9ecc50bbcf543f5a"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "libusb1 udev"
+
+inherit autotools pkgconfig


### PR DESCRIPTION
The [rkdeveloptool](https://github.com/rockchip-linux/rkdeveloptool) enables communication with the Boot ROM of various
Rockchip SoCs.

It allows uploading software, writing/reading memory and resetting the CPU/running code.

This could be a replacement for #210, which enables using `rkdeveloptool` installed into a Debian container.