### PR TITLE
meta-lxatac-bsp: lxatac-net-switch-hacks: workarounds for connection losses

### DIFF
--- a/meta-lxatac-bsp/recipes-core/images/lxatac-core-image-base.bbappend
+++ b/meta-lxatac-bsp/recipes-core/images/lxatac-core-image-base.bbappend
@@ -15,4 +15,5 @@ IMAGE_INSTALL:append = "\
     kernel-modules \
     kernel-devicetree \
     dt-utils-barebox-state \
+    lxatac-net-switch-hacks \
 "

--- a/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/01-increase-atomic-mem-pool-size.conf
+++ b/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/01-increase-atomic-mem-pool-size.conf
@@ -1,0 +1,1 @@
+vm.min_free_kbytes=8192

--- a/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/60-spi-device.rules
+++ b/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/60-spi-device.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="platform", DRIVER=="spi_stm32", TAG+="systemd"

--- a/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/spi-irq-prio-44009000.service
+++ b/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/files/spi-irq-prio-44009000.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Increase kernel thread priority for the SPI bus to prevent timeouts
+BindsTo=sys-devices-platform-soc-5c007000.bus-44009000.spi.device
+After=sys-devices-platform-soc-5c007000.bus-44009000.spi.device
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sh -c "chrt --pid 55 `pgrep irq/[0-9]+-44009000`"
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/lxatac-net-switch-hacks.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/lxatac-net-switch-hacks.bb
@@ -1,10 +1,12 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit allarch
+inherit allarch systemd
 
 SRC_URI += " \
     file://01-increase-atomic-mem-pool-size.conf \
+    file://60-spi-device.rules \
+    file://spi-irq-prio-44009000.service \
 "
 
 do_install() {
@@ -14,8 +16,28 @@ do_install() {
     # under high load.
     install -D -m0644 ${WORKDIR}/01-increase-atomic-mem-pool-size.conf \
         ${D}${libdir}/sysctl.d/01-increase-atomic-mem-pool-size.conf
+
+    # Tag the SPI bus controllers with the `systemd` udev tag.
+    # This makes systemd create units like
+    #   sys-devices-platform-soc-5c007000.bus-44009000.spi.device
+    # that we can use as `Requires=` and `After=` in other units.
+    install -D -m0644 ${WORKDIR}/60-spi-device.rules \
+        ${D}${sysconfdir}/udev/rules.d/60-spi-device.rules
+
+    # Increase the priority of the kernel thread that handles the
+    # interrupts for the SPI controller the ethernet switch is connected to.
+    # This prevents timeouts when communicating with the switch while the
+    # system is under high load.
+    install -D -m0644 ${WORKDIR}/spi-irq-prio-44009000.service \
+        ${D}${systemd_system_unitdir}/spi-irq-prio-44009000.service
 }
+
+SYSTEMD_SERVICE:${PN} = "spi-irq-prio-44009000.service"
+
+# For chrt and pgrep in spi-irq-prio-44009000.service
+RDEPENDS:${PN} += "util-linux busybox"
 
 FILES:${PN} += "\
     ${libdir}/sysctl.d/ \
+    ${sysconfdir} \
 "

--- a/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/lxatac-net-switch-hacks.bb
+++ b/meta-lxatac-bsp/recipes-core/lxatac-net-switch-hacks/lxatac-net-switch-hacks.bb
@@ -1,0 +1,21 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch
+
+SRC_URI += " \
+    file://01-increase-atomic-mem-pool-size.conf \
+"
+
+do_install() {
+    # Increase the kernel atomic memory pool size.
+    # This pool is used for allocations in the hot path.
+    # It seems like the kernel sometimes runs out of memory in this pool when
+    # under high load.
+    install -D -m0644 ${WORKDIR}/01-increase-atomic-mem-pool-size.conf \
+        ${D}${libdir}/sysctl.d/01-increase-atomic-mem-pool-size.conf
+}
+
+FILES:${PN} += "\
+    ${libdir}/sysctl.d/ \
+"


### PR DESCRIPTION
This PR adds two workarounds that should make the network connection more reliable under high loads:

## Increase atomic memory pool size

When experiencing load the kernels default `min_free_kbytes` (of around 2M) seem to little. Hot paths can run out of memory.
Increasing the limit to 8M seems to mitigate the problem.

This manifests in issues in communicating with the ethernet switch under high loads, resulting in network connection losses.

This is only fighting symptoms of an underlying issue, which why it is marked as a hack.

## Increase SPI kernel thread priority

When the system is under high load some SPI transfers with the ethernet switch will time out before they are handled.

Increase the priority of the kernel thread that handles the SPI transfer to work around the issue.

It does not make a lot of sense for a SPI transfer, that is 100% under the hosts control (it does not and can not wait for the device for example) to time out in the first place.
This means we are only fighting symptoms here, which is why this change is also marked as a hack.