### PR TITLE
meta-lxatac-software: lxatac-core-image-base: install networkmanager meta package

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -85,8 +85,7 @@ IMAGE_INSTALL:append = "\
     microcom \
     mmc-utils \
     nano \
-    networkmanager-nmcli \
-    networkmanager-nmtui \
+    networkmanager \
     nfs-utils-client \
     nftables \
     openocd \


### PR DESCRIPTION
We define DISTRO_FEATURES such as "wifi", "bluetooth" or "systemd" already. Let's make use of that and install the networkmanager meta package. More useful features are pulled in depending on the DISTRO_FEATURES and PACKAGECONFIG options set.
```
$ bitbake-getvar -r networkmanager PACKAGECONFIG
[...]
PACKAGECONFIG="readline nss ifupdown dnsmasq nmcli vala systemd bluez5 polkit wifi nmtui"
```
nmcli is still installed due to it being a part of networkmanager's default PACKAGECONFIG.
nmtui is also installed due to our networkmanager_%.bbappend appending it to networkmanager's PACKAGECONFIG.

With this change, wifi and bluetooth functionality is now available.