### PR TITLE
meta-lxatac-bsp: barebox: import dts changes send to Linux mainline and cleanup patchstack

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0001-scripts-implement-slurp-a-read_file-with-fd-as-argum.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0001-scripts-implement-slurp-a-read_file-with-fd-as-argum.patch
@@ -6,6 +6,7 @@ This is useful for host/target tools that use stdin as a fall back to
 read from when no file name is supplied.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  scripts/common.c | 29 +++++++++++++++++++++++++++++
  scripts/common.h |  1 +

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0002-of_path-support-phandles-in-of_find_path.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0002-of_path-support-phandles-in-of_find_path.patch
@@ -15,6 +15,7 @@ heuristically, we add a new OF_FIND_PATH_FLAGS_PHANDLE0 to decode first
 property cell as phandle.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  drivers/of/of_path.c | 49 ++++++++++++++++++++++++++++++++-----------------
  include/of.h         |  3 ++-

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0003-Makefile-add-common-boards-include-to-include-search.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0003-Makefile-add-common-boards-include-to-include-search.patch
@@ -6,6 +6,7 @@ This new directory should be used for board-specific headers,
 e.g. common data structures for factory data.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  Makefile | 1 +
  1 file changed, 1 insertion(+)

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0004-net-add-ethaddr-sequence-handling.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0004-net-add-ethaddr-sequence-handling.patch
@@ -14,6 +14,7 @@ to iterate over such an Ethernet address sequence. Example usage:
           eth_register_ethaddr(i++, eth_addr);
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  include/net.h | 20 ++++++++++++++++++++
  1 file changed, 20 insertions(+)

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0005-common-add-optional-systemd.hostname-generation.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0005-common-add-optional-systemd.hostname-generation.patch
@@ -7,6 +7,7 @@ appended by "-${global.serial_number} is a sane default. Add a Kconfig
 option to enable this.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  common/Kconfig |  8 ++++++++
  common/misc.c  | 16 ++++++++++++++++

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0006-net-factor-out-eth_of_get_fixup_node.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0006-net-factor-out-eth_of_get_fixup_node.patch
@@ -8,6 +8,7 @@ assignment code, so board code can use this to retrace which MAC
 addresses would be fixed up.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  include/net.h | 12 ++++++++++++
  net/eth.c     | 29 +++++++++++++++++++----------

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0007-net-export-list-of-registered-ethernet-addresses.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0007-net-export-list-of-registered-ethernet-addresses.patch
@@ -18,6 +18,7 @@ handles both cases already), but it allows future board code to consult
 the list to check which Ethernet addresses were actually assigned.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  include/net.h |  9 +++++++++
  net/eth.c     | 11 ++---------

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0008-net-implement-ethaddr_string_cmp.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0008-net-implement-ethaddr_string_cmp.patch
@@ -9,6 +9,7 @@ one more function to compare a text string with binary. This will be
 used in a follow up commit.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  include/net.h |  2 ++
  net/lib.c     | 17 +++++++++++++++++

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0009-common-add-barebox-TLV-support.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0009-common-add-barebox-TLV-support.patch
@@ -8,6 +8,7 @@ is limited to already specified tags, it can be extended later on,
 without modifying the bootloader binary.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  common/Kconfig        |  24 +++++++
  common/Makefile       |   1 +

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0010-commands-add-TLV-debugging-command.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0010-commands-add-TLV-debugging-command.patch
@@ -6,6 +6,7 @@ The TLV command does the equivalent of having a "barebox,tlv"
 compatible node point at the file. It's meant as a debugging aid.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  commands/Kconfig  | 12 ++++++++++++
  commands/Makefile |  1 +

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0011-scripts-add-bareboxtlv-host-target-tool.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0011-scripts-add-bareboxtlv-host-target-tool.patch
@@ -15,6 +15,7 @@ Example uses:
   ./scripts/bareboxtlv -m 0xcfe01001 -v tlv.blob && echo CRC correct
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  scripts/.gitignore                |   2 +
  scripts/Makefile                  |   2 +

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0101-boards-add-decoder-for-LXA-TLV-v1-format.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0101-boards-add-decoder-for-LXA-TLV-v1-format.patch
@@ -6,6 +6,7 @@ The LXA TLV format is stored onto the EEPROM of either the Baseboard or
 Powerboard. Its contents are mainly for use in Linux userspace.
 
 Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
+Upstream-Status: Pending
 ---
  common/boards/Kconfig                  |  5 ++
  common/boards/Makefile                 |  1 +

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0102-ARM-dts-stm32-lxa-tac-fix-gen-1-2-boards-and-add-gen.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0102-ARM-dts-stm32-lxa-tac-fix-gen-1-2-boards-and-add-gen.patch
@@ -1,178 +1,57 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Fri, 22 Mar 2024 07:52:39 +0100
-Subject: [PATCH] ARM: stm32mp: add Linux Automation TAC Generation 3
+Date: Tue, 15 Jun 2021 21:18:38 +0200
+Subject: [PATCH] ARM: dts: stm32: lxa-tac: fix gen{1,2} boards and add gen3
+ board
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-The hardware generation 3 moves a few GPIOs around,
-making some devicetree changes necessary.
+this series fixes some problems found in the lxa-tac generation 1 and
+2 boards and add support for the generation 3 board. It's based on an
+STM32MP153c, while the generation 1 and 2 are based on the
+STM32MP157c.
 
 Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
+Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
+Upstream-Status: Submitted [https://patch.msgid.link/20241119-lxa-tac-gen3-v1-0-e0ab0a369372@pengutronix.de]
 ---
- arch/arm/boards/lxa-tac/board.c             |   1 +
- arch/arm/boards/lxa-tac/lowlevel.c          |   6 +
- arch/arm/dts/Makefile                       |   3 +-
- arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts   |  38 +++++
- dts/Bindings/arm/stm32/stm32.yaml           |   1 +
- dts/src/arm/st/stm32mp15-pinctrl.dtsi       |  14 ++
- dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts | 245 ++++++++++++++++++++++++++++
- dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts |  78 +++++++++
- dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts |  77 +++++++++
- dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi     |  80 +--------
- 10 files changed, 466 insertions(+), 77 deletions(-)
- create mode 100644 arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
+ dts/Bindings/arm/stm32/stm32.yaml           |   7 +
+ dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts | 267 ++++++++++++++++++++++++++++
+ dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts |  84 +++++++++
+ dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts |  84 +++++++++
+ dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi     | 100 ++---------
+ 5 files changed, 454 insertions(+), 88 deletions(-)
  create mode 100644 dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts
 
-diff --git a/arch/arm/boards/lxa-tac/board.c b/arch/arm/boards/lxa-tac/board.c
-index c7e8d0f1af1f..d124452d09c3 100644
---- a/arch/arm/boards/lxa-tac/board.c
-+++ b/arch/arm/boards/lxa-tac/board.c
-@@ -36,6 +36,7 @@ static int tac_probe(struct device *dev)
- static const struct of_device_id tac_of_match[] = {
- 	{ .compatible = "lxa,stm32mp157c-tac-gen1" },
- 	{ .compatible = "lxa,stm32mp157c-tac-gen2" },
-+	{ .compatible = "lxa,stm32mp153c-tac-gen3" },
- 	{ /* sentinel */ },
- };
- BAREBOX_DEEP_PROBE_ENABLE(tac_of_match);
-diff --git a/arch/arm/boards/lxa-tac/lowlevel.c b/arch/arm/boards/lxa-tac/lowlevel.c
-index bb0600b4d66c..bfb7aca29917 100644
---- a/arch/arm/boards/lxa-tac/lowlevel.c
-+++ b/arch/arm/boards/lxa-tac/lowlevel.c
-@@ -6,6 +6,7 @@
- 
- extern char __dtb_z_stm32mp157c_lxa_tac_gen1_start[];
- extern char __dtb_z_stm32mp157c_lxa_tac_gen2_start[];
-+extern char __dtb_z_stm32mp153c_lxa_tac_gen3_start[];
- 
- /* Major board generation is set via traces in copper
-  * Minor board generation can be changed via resistors.
-@@ -14,6 +15,7 @@ extern char __dtb_z_stm32mp157c_lxa_tac_gen2_start[];
- #define BOARD_GEN(major, minor) (major << 2 | minor)
- #define BOARD_GEN1 BOARD_GEN(0, 0)
- #define BOARD_GEN2 BOARD_GEN(1, 0)
-+#define BOARD_GEN3 BOARD_GEN(2, 0)
- 
- #define RCC_MP_AHB5ENSETR ((void *)0x50000210)
- #define GPIOZ_BASE ((void *)0x54004000)
-@@ -51,6 +53,10 @@ static void noinline select_fdt_and_start(void *fdt)
- 		fdt = __dtb_z_stm32mp157c_lxa_tac_gen2_start
- 			+ get_runtime_offset();
- 		break;
-+	case BOARD_GEN3:
-+		fdt = __dtb_z_stm32mp153c_lxa_tac_gen3_start
-+			+ get_runtime_offset();
-+		break;
- 	}
- 
- 	stm32mp1_barebox_entry(fdt);
-diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 1bac17112340..bcdc8d607c35 100644
---- a/arch/arm/dts/Makefile
-+++ b/arch/arm/dts/Makefile
-@@ -149,7 +149,8 @@ lwl-$(CONFIG_MACH_STM32MP15XX_DKX) += stm32mp157c-dk2.dtb.o stm32mp157a-dk1.dtb.
- 					stm32mp157c-dk2-scmi.dtb.o stm32mp157a-dk1-scmi.dtb.o
- lwl-$(CONFIG_MACH_STM32MP13XX_DK) += stm32mp135f-dk.dtb.o
- lwl-$(CONFIG_MACH_LXA_MC1) += stm32mp157c-lxa-mc1.dtb.o stm32mp157c-lxa-mc1-scmi.dtb.o
--lwl-$(CONFIG_MACH_LXA_TAC) += stm32mp157c-lxa-tac-gen1.dtb.o stm32mp157c-lxa-tac-gen2.dtb.o
-+lwl-$(CONFIG_MACH_LXA_TAC) += stm32mp157c-lxa-tac-gen1.dtb.o stm32mp157c-lxa-tac-gen2.dtb.o \
-+				stm32mp153c-lxa-tac-gen3.dtb.o
- lwl-$(CONFIG_MACH_STM32MP15X_EV1) += stm32mp157c-ev1.dtb.o stm32mp157c-ev1-scmi.dtb.o
- lwl-$(CONFIG_MACH_SCB9328) += imx1-scb9328.dtb.o
- lwl-$(CONFIG_MACH_TECHNEXION_WANDBOARD) += imx6q-wandboard.dtb.o imx6dl-wandboard.dtb.o
-diff --git a/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts b/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
-new file mode 100644
-index 000000000000..ab46e11d396d
---- /dev/null
-+++ b/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
-@@ -0,0 +1,38 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
-+/*
-+ * Copyright (C) 2024 Leonard Göhrs, Pengutronix
-+ */
-+
-+#include <arm/st/stm32mp153c-lxa-tac-gen3.dts>
-+#include "stm32mp15xc-lxa-tac.dtsi"
-+
-+/ {
-+	led-controller-pwm {
-+		compatible = "pwm-leds";
-+
-+		led-status-red {
-+			label = "pwm:red:status";
-+			pwms = <&led_pwm 0 1000000 0>;
-+			active-low;
-+			max-brightness = <255>;
-+		};
-+
-+		led-status-green {
-+			label = "pwm:green:status";
-+			pwms = <&led_pwm 2 1000000 0>;
-+			active-low;
-+			max-brightness = <255>;
-+		};
-+
-+		led-status-blue {
-+			label = "pwm:blue:status";
-+			pwms = <&led_pwm 1 1000000 0>;
-+			active-low;
-+			max-brightness = <255>;
-+		};
-+	};
-+
-+	led-controller-1 {
-+		status = "disabled";
-+	};
-+};
 diff --git a/dts/Bindings/arm/stm32/stm32.yaml b/dts/Bindings/arm/stm32/stm32.yaml
-index 58099949e8f3..499ed9b5250c 100644
+index 58099949e8f3..947f672dfc91 100644
 --- a/dts/Bindings/arm/stm32/stm32.yaml
 +++ b/dts/Bindings/arm/stm32/stm32.yaml
-@@ -142,6 +142,7 @@ properties:
-               - lxa,stm32mp157c-mc1      # Linux Automation MC-1
-               - lxa,stm32mp157c-tac-gen1 # Linux Automation TAC (Generation 1)
-               - lxa,stm32mp157c-tac-gen2 # Linux Automation TAC (Generation 2)
-+              - lxa,stm32mp153c-tac-gen3 # Linux Automation TAC (Generation 3)
-               - oct,stm32mp157c-osd32-red # Octavo OSD32MP1 RED board
-           - const: oct,stm32mp15xx-osd32
-           - enum:
-diff --git a/dts/src/arm/st/stm32mp15-pinctrl.dtsi b/dts/src/arm/st/stm32mp15-pinctrl.dtsi
-index ae83e7b10232..54dbb58ba4c2 100644
---- a/dts/src/arm/st/stm32mp15-pinctrl.dtsi
-+++ b/dts/src/arm/st/stm32mp15-pinctrl.dtsi
-@@ -18,6 +18,20 @@ pins {
- 		};
- 	};
+@@ -83,6 +83,13 @@ properties:
+           - const: dh,stm32mp153c-dhcor-som
+           - const: st,stm32mp153
  
-+	/omit-if-no-ref/
-+	adc1_ain_pins_b: adc1-ain-1 {
-+		pins {
-+			pinmux = <STM32_PINMUX('F', 11, ANALOG)>, /* ADC1_INP2 */
-+				 <STM32_PINMUX('B', 1, ANALOG)>, /* ADC1_INP5 */
-+				 <STM32_PINMUX('B', 0, ANALOG)>, /* ADC1_INP9 */
-+				 <STM32_PINMUX('C', 0, ANALOG)>, /* ADC1_INP10 */
-+				 <STM32_PINMUX('C', 3, ANALOG)>, /* ADC1_INP13 */
-+				 <STM32_PINMUX('A', 2, ANALOG)>, /* ADC1_INP14 */
-+				 <STM32_PINMUX('A', 3, ANALOG)>, /* ADC1_INP15 */
-+				 <STM32_PINMUX('A', 4, ANALOG)>; /* ADC1_INP18 */
-+		};
-+	};
++      - description: Octavo OSD32MP153 System-in-Package based boards
++        items:
++          - enum:
++              - lxa,stm32mp153c-tac-gen3 # Linux Automation TAC (Generation 3)
++          - const: oct,stm32mp153x-osd32
++          - const: st,stm32mp153
 +
- 	/omit-if-no-ref/
- 	adc1_in6_pins_a: adc1-in6-0 {
- 		pins {
+       - items:
+           - enum:
+               - shiratech,stm32mp157a-iot-box # IoT Box
 diff --git a/dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts b/dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts
 new file mode 100644
-index 000000000000..35b986612f0f
+index 000000000000..a40b0eae8da3
 --- /dev/null
 +++ b/dts/src/arm/st/stm32mp153c-lxa-tac-gen3.dts
-@@ -0,0 +1,245 @@
+@@ -0,0 +1,267 @@
 +// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
 +/*
 + * Copyright (C) 2020 STMicroelectronics - All Rights Reserved
 + * Copyright (C) 2021 Rouven Czerwinski, Pengutronix
-+ * Copyright (C) 2024 Leonard Göhrs, Pengutronix
++ * Copyright (C) 2023, 2024 Leonard Göhrs, Pengutronix
 + */
 +
 +/dts-v1/;
@@ -182,7 +61,7 @@ index 000000000000..35b986612f0f
 +
 +/ {
 +	model = "Linux Automation Test Automation Controller (TAC) Gen 3";
-+	compatible = "lxa,stm32mp153c-tac-gen3", "oct,stm32mp15xx-osd32", "st,stm32mp153";
++	compatible = "lxa,stm32mp153c-tac-gen3", "oct,stm32mp153x-osd32", "st,stm32mp153";
 +
 +	backlight: backlight {
 +		compatible = "pwm-backlight";
@@ -293,7 +172,7 @@ index 000000000000..35b986612f0f
 +
 +&adc {
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&adc1_ain_pins_b>;
++	pinctrl-0 = <&board_adc1_ain_pins>;
 +	vdd-supply = <&vdd>;
 +	vdda-supply = <&vdda>;
 +	vref-supply = <&vrefbuf>;
@@ -376,14 +255,36 @@ index 000000000000..35b986612f0f
 +
 +&gpioe {
 +	gpio-line-names = "TP35", "", "", "", "CAN_1_120R", /*  0 */
-+	"", "", "USER_BTN2", "DUT_POWER_EN", "UART_TX_EN",  /*  5 */
++	"", "", "USER_BTN2", "DUT_PWR_EN", "UART_TX_EN",    /*  5 */
 +	"UART_RX_EN", "TP24", "", "TP25", "TP26",           /* 10 */
 +	"TP27";                                             /* 15 */
++};
++
++&gpiog {
++	gpio-line-names = "ETH_RESET", "", "", "", "",               /*  0 */
++	"IOBUS_FLT_FB", "", "USER_LED2", "ETH1_PPS_A", "CAN_0_120R", /*  5 */
++	"POWER_ADC_RESET", "", "", "", "",                           /* 10 */
++	"";                                                          /* 15 */
 +};
 +
 +&m_can2 {
 +	termination-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>;
 +	termination-ohms = <120>;
++};
++
++&pinctrl {
++	board_adc1_ain_pins: board-adc1-ain-0 {
++		pins {
++			pinmux = <STM32_PINMUX('F', 11, ANALOG)>, /* ADC1_INP2 */
++				 <STM32_PINMUX('B', 1, ANALOG)>, /* ADC1_INP5 */
++				 <STM32_PINMUX('B', 0, ANALOG)>, /* ADC1_INP9 */
++				 <STM32_PINMUX('C', 0, ANALOG)>, /* ADC1_INP10 */
++				 <STM32_PINMUX('C', 3, ANALOG)>, /* ADC1_INP13 */
++				 <STM32_PINMUX('A', 2, ANALOG)>, /* ADC1_INP14 */
++				 <STM32_PINMUX('A', 3, ANALOG)>, /* ADC1_INP15 */
++				 <STM32_PINMUX('A', 4, ANALOG)>; /* ADC1_INP18 */
++		};
++	};
 +};
 +
 +&spi2 {
@@ -414,14 +315,13 @@ index 000000000000..35b986612f0f
 +	};
 +};
 diff --git a/dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts b/dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts
-index 81f254fb88b0..2dd158841c85 100644
+index 81f254fb88b0..e72e42eb0eb4 100644
 --- a/dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts
 +++ b/dts/src/arm/st/stm32mp157c-lxa-tac-gen1.dts
-@@ -35,6 +35,77 @@ reg_iobus_12v: regulator-iobus-12v {
+@@ -35,6 +35,76 @@ reg_iobus_12v: regulator-iobus-12v {
  	};
  };
  
-+
 +&adc {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&adc1_ain_pins_a>;
@@ -495,7 +395,7 @@ index 81f254fb88b0..2dd158841c85 100644
  &gpioa {
  	gpio-line-names = "", "", "STACK_CS2", "", "STACK_CS3", /*  0 */
  	"ETH_GPIO1", "ETH_INT", "", "", "",                     /*  5 */
-@@ -48,6 +119,13 @@ &gpioc {
+@@ -48,6 +118,20 @@ &gpioc {
  	"", "";                                        /* 10 */
  };
  
@@ -506,11 +406,18 @@ index 81f254fb88b0..2dd158841c85 100644
 +	"TP27";                                             /* 15 */
 +};
 +
++&gpiog {
++	gpio-line-names = "ETH_RESET", "", "", "", "",               /*  0 */
++	"IOBUS_FLT_FB", "", "USER_LED2", "ETH1_PPS_A", "CAN_0_120R", /*  5 */
++	"TP49", "", "", "", "",                                      /* 10 */
++	"";                                                          /* 15 */
++};
++
  &gpu {
  	status = "disabled";
  };
 diff --git a/dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts b/dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts
-index 4cc177031661..1fac9bb60cfb 100644
+index 4cc177031661..2ae281725a48 100644
 --- a/dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts
 +++ b/dts/src/arm/st/stm32mp157c-lxa-tac-gen2.dts
 @@ -121,6 +121,76 @@ led-15 {
@@ -590,7 +497,7 @@ index 4cc177031661..1fac9bb60cfb 100644
  &gpioa {
  	gpio-line-names = "", "", "DUT_PWR_EN", "", "STACK_CS3", /*  0 */
  	"ETH_GPIO1", "ETH_INT", "", "", "",                      /*  5 */
-@@ -134,6 +204,13 @@ &gpioc {
+@@ -134,6 +204,20 @@ &gpioc {
  	"", "";                                            /* 10 */
  };
  
@@ -601,14 +508,42 @@ index 4cc177031661..1fac9bb60cfb 100644
 +	"TP27";                                             /* 15 */
 +};
 +
++&gpiog {
++	gpio-line-names = "ETH_RESET", "", "", "", "",               /*  0 */
++	"IOBUS_FLT_FB", "", "USER_LED2", "ETH1_PPS_A", "CAN_0_120R", /*  5 */
++	"TP49", "", "", "", "",                                      /* 10 */
++	"";                                                          /* 15 */
++};
++
  &gpu {
  	status = "disabled";
  };
 diff --git a/dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi b/dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi
-index c87fd96cbd91..ca94a1e0ff66 100644
+index c87fd96cbd91..be0c355d3105 100644
 --- a/dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi
 +++ b/dts/src/arm/st/stm32mp15xc-lxa-tac.dtsi
-@@ -142,75 +142,6 @@ output-vuart {
+@@ -16,12 +16,20 @@
+ 
+ / {
+ 	aliases {
++		can0 = &m_can1;
++		can1 = &m_can2;
+ 		ethernet0 = &ethernet0;
+ 		ethernet1 = &port_uplink;
+ 		ethernet2 = &port_dut;
++		i2c0 = &i2c1;
++		i2c1 = &i2c4;
++		i2c2 = &i2c5;
+ 		mmc1 = &sdmmc2;
+ 		serial0 = &uart4;
+ 		serial1 = &usart3;
++		spi0 = &spi2;
++		spi1 = &spi4;
++		spi2 = &spi5;
+ 	};
+ 
+ 	chosen {
+@@ -142,76 +150,6 @@ output-vuart {
  baseboard_eeprom: &sip_eeprom {
  };
  
@@ -681,10 +616,11 @@ index c87fd96cbd91..ca94a1e0ff66 100644
 -		};
 -	};
 -};
- 
+-
  &crc1 {
  	status = "okay";
-@@ -265,13 +196,6 @@ &gpiod {
+ };
+@@ -265,13 +203,6 @@ &gpiod {
  	"ETH_LAB_LEDRN";                          /* 15 */
  };
  
@@ -698,7 +634,32 @@ index c87fd96cbd91..ca94a1e0ff66 100644
  &gpiof {
  	gpio-line-names = "TP36", "TP37", "", "", "OLED_CS", /*  0 */
  	"", "", "", "", "",                                  /*  5 */
-@@ -576,6 +500,10 @@ &usbotg_hs {
+@@ -279,13 +210,6 @@ &gpiof {
+ 	"";                                                  /* 15 */
+ };
+ 
+-&gpiog {
+-	gpio-line-names = "ETH_RESET", "", "", "", "",               /*  0 */
+-	"IOBUS_FLT_FB", "", "USER_LED2", "ETH1_PPS_A", "CAN_0_120R", /*  5 */
+-	"TP49", "", "", "", "",                                      /* 10 */
+-	"";                                                          /* 15 */
+-};
+-
+ &gpioh {
+ 	gpio-line-names = "", "", "OUT_1", "OUT_0", "OLED_RESET", /*  0 */
+ 	"", "", "", "", "",                                       /*  5 */
+@@ -379,10 +303,6 @@ regulators {
+ 	};
+ };
+ 
+-&rtc {
+-	status = "okay";
+-};
+-
+ &sdmmc2 {
+ 	pinctrl-names = "default", "opendrain", "sleep";
+ 	pinctrl-0 = <&sdmmc2_b4_pins_a &sdmmc2_d47_pins_b>;
+@@ -576,6 +496,10 @@ &usbotg_hs {
  	vusb_d-supply = <&vdd_usb>;
  	vusb_a-supply = <&reg18>;
  

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0103-ARM-stm32mp-add-Linux-Automation-TAC-board.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0103-ARM-stm32mp-add-Linux-Automation-TAC-board.patch
@@ -11,21 +11,25 @@ no previous barebox has been put into the eMMC boot partition.
 
 Signed-off-by: Leonard Göhrs <l.goehrs@pengutronix.de>
 Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
+Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
+Upstream-Status: Pending
 ---
  arch/arm/boards/Makefile                  |   1 +
  arch/arm/boards/lxa-tac/Makefile          |   2 +
- arch/arm/boards/lxa-tac/board.c           |  48 +++++++++++
- arch/arm/boards/lxa-tac/lowlevel.c        |  68 +++++++++++++++
- arch/arm/dts/Makefile                     |   1 +
+ arch/arm/boards/lxa-tac/board.c           |  49 +++++++++++
+ arch/arm/boards/lxa-tac/lowlevel.c        |  77 +++++++++++++++++
+ arch/arm/dts/Makefile                     |   2 +
+ arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts |  38 ++++++++
  arch/arm/dts/stm32mp157c-lxa-tac-gen1.dts |   7 ++
  arch/arm/dts/stm32mp157c-lxa-tac-gen2.dts |  38 ++++++++
  arch/arm/dts/stm32mp15xc-lxa-tac.dtsi     | 138 ++++++++++++++++++++++++++++++
  arch/arm/mach-stm32mp/Kconfig             |   5 ++
  images/Makefile.stm32mp                   |   4 +
- 10 files changed, 312 insertions(+)
+ 11 files changed, 361 insertions(+)
  create mode 100644 arch/arm/boards/lxa-tac/Makefile
  create mode 100644 arch/arm/boards/lxa-tac/board.c
  create mode 100644 arch/arm/boards/lxa-tac/lowlevel.c
+ create mode 100644 arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
  create mode 100644 arch/arm/dts/stm32mp157c-lxa-tac-gen1.dts
  create mode 100644 arch/arm/dts/stm32mp157c-lxa-tac-gen2.dts
  create mode 100644 arch/arm/dts/stm32mp15xc-lxa-tac.dtsi
@@ -52,10 +56,10 @@ index 000000000000..092c31d6b28d
 +obj-y += board.o
 diff --git a/arch/arm/boards/lxa-tac/board.c b/arch/arm/boards/lxa-tac/board.c
 new file mode 100644
-index 000000000000..c7e8d0f1af1f
+index 000000000000..d124452d09c3
 --- /dev/null
 +++ b/arch/arm/boards/lxa-tac/board.c
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +#include <common.h>
 +#include <linux/sizes.h>
@@ -94,6 +98,7 @@ index 000000000000..c7e8d0f1af1f
 +static const struct of_device_id tac_of_match[] = {
 +	{ .compatible = "lxa,stm32mp157c-tac-gen1" },
 +	{ .compatible = "lxa,stm32mp157c-tac-gen2" },
++	{ .compatible = "lxa,stm32mp153c-tac-gen3" },
 +	{ /* sentinel */ },
 +};
 +BAREBOX_DEEP_PROBE_ENABLE(tac_of_match);
@@ -106,10 +111,10 @@ index 000000000000..c7e8d0f1af1f
 +late_platform_driver(tac_board_driver);
 diff --git a/arch/arm/boards/lxa-tac/lowlevel.c b/arch/arm/boards/lxa-tac/lowlevel.c
 new file mode 100644
-index 000000000000..bb0600b4d66c
+index 000000000000..75e13417c209
 --- /dev/null
 +++ b/arch/arm/boards/lxa-tac/lowlevel.c
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,77 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +#include <common.h>
 +#include <debug_ll.h>
@@ -118,14 +123,18 @@ index 000000000000..bb0600b4d66c
 +
 +extern char __dtb_z_stm32mp157c_lxa_tac_gen1_start[];
 +extern char __dtb_z_stm32mp157c_lxa_tac_gen2_start[];
++extern char __dtb_z_stm32mp153c_lxa_tac_gen3_start[];
 +
-+/* Major board generation is set via traces in copper
++/*
++ * Major board generation is set via traces in copper
 + * Minor board generation can be changed via resistors.
 + * The revision is available on GPIOs:
-+ * [PZ0, PZ1, PZ2, PZ3, PZ6, PZ7] */
++ * [PZ0, PZ1, PZ2, PZ3, PZ6, PZ7]
++ */
 +#define BOARD_GEN(major, minor) (major << 2 | minor)
 +#define BOARD_GEN1 BOARD_GEN(0, 0)
 +#define BOARD_GEN2 BOARD_GEN(1, 0)
++#define BOARD_GEN3 BOARD_GEN(2, 0)
 +
 +#define RCC_MP_AHB5ENSETR ((void *)0x50000210)
 +#define GPIOZ_BASE ((void *)0x54004000)
@@ -140,7 +149,7 @@ index 000000000000..bb0600b4d66c
 +	/* Enable GPIOZ bank */
 +	setbits_le32(RCC_MP_AHB5ENSETR, BIT(0));
 +
-+	for (i=0; i<ARRAY_SIZE(board_rev_pins); i++) {
++	for (i = 0; i < ARRAY_SIZE(board_rev_pins); i++) {
 +		int pin = board_rev_pins[i];
 +
 +		__stm32_pmx_gpio_input(GPIOZ_BASE, pin);
@@ -156,12 +165,16 @@ index 000000000000..bb0600b4d66c
 +
 +	switch (get_board_rev()) {
 +	case BOARD_GEN1:
-+		fdt = __dtb_z_stm32mp157c_lxa_tac_gen1_start
-+			+ get_runtime_offset();
++		fdt = __dtb_z_stm32mp157c_lxa_tac_gen1_start +
++			get_runtime_offset();
 +		break;
 +	case BOARD_GEN2:
-+		fdt = __dtb_z_stm32mp157c_lxa_tac_gen2_start
-+			+ get_runtime_offset();
++		fdt = __dtb_z_stm32mp157c_lxa_tac_gen2_start +
++			get_runtime_offset();
++		break;
++	case BOARD_GEN3:
++		fdt = __dtb_z_stm32mp153c_lxa_tac_gen3_start +
++			get_runtime_offset();
 +		break;
 +	}
 +
@@ -172,24 +185,70 @@ index 000000000000..bb0600b4d66c
 +{
 +	stm32mp_cpu_lowlevel_init();
 +
-+	/* stm32mp_cpu_lowlevel_init sets up a stack.
-+	 * Do the remaining init in a non-naked function.
-+	 * Register r2 points to the fdt from the FIT image
-+	 * which can be used as a default. */
++	/*
++	 * stm32mp_cpu_lowlevel_init sets up a stack. Do the remaining
++	 * init in a non-naked function. Register r2 points to the fdt
++	 * from the FIT image which can be used as a default.
++	 */
 +	select_fdt_and_start((void *)r2);
 +}
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 3b3236b4165f..1bac17112340 100644
+index 3b3236b4165f..bcdc8d607c35 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -149,6 +149,7 @@ lwl-$(CONFIG_MACH_STM32MP15XX_DKX) += stm32mp157c-dk2.dtb.o stm32mp157a-dk1.dtb.
+@@ -149,6 +149,8 @@ lwl-$(CONFIG_MACH_STM32MP15XX_DKX) += stm32mp157c-dk2.dtb.o stm32mp157a-dk1.dtb.
  					stm32mp157c-dk2-scmi.dtb.o stm32mp157a-dk1-scmi.dtb.o
  lwl-$(CONFIG_MACH_STM32MP13XX_DK) += stm32mp135f-dk.dtb.o
  lwl-$(CONFIG_MACH_LXA_MC1) += stm32mp157c-lxa-mc1.dtb.o stm32mp157c-lxa-mc1-scmi.dtb.o
-+lwl-$(CONFIG_MACH_LXA_TAC) += stm32mp157c-lxa-tac-gen1.dtb.o stm32mp157c-lxa-tac-gen2.dtb.o
++lwl-$(CONFIG_MACH_LXA_TAC) += stm32mp157c-lxa-tac-gen1.dtb.o stm32mp157c-lxa-tac-gen2.dtb.o \
++				stm32mp153c-lxa-tac-gen3.dtb.o
  lwl-$(CONFIG_MACH_STM32MP15X_EV1) += stm32mp157c-ev1.dtb.o stm32mp157c-ev1-scmi.dtb.o
  lwl-$(CONFIG_MACH_SCB9328) += imx1-scb9328.dtb.o
  lwl-$(CONFIG_MACH_TECHNEXION_WANDBOARD) += imx6q-wandboard.dtb.o imx6dl-wandboard.dtb.o
+diff --git a/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts b/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
+new file mode 100644
+index 000000000000..ab46e11d396d
+--- /dev/null
++++ b/arch/arm/dts/stm32mp153c-lxa-tac-gen3.dts
+@@ -0,0 +1,38 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (C) 2024 Leonard Göhrs, Pengutronix
++ */
++
++#include <arm/st/stm32mp153c-lxa-tac-gen3.dts>
++#include "stm32mp15xc-lxa-tac.dtsi"
++
++/ {
++	led-controller-pwm {
++		compatible = "pwm-leds";
++
++		led-status-red {
++			label = "pwm:red:status";
++			pwms = <&led_pwm 0 1000000 0>;
++			active-low;
++			max-brightness = <255>;
++		};
++
++		led-status-green {
++			label = "pwm:green:status";
++			pwms = <&led_pwm 2 1000000 0>;
++			active-low;
++			max-brightness = <255>;
++		};
++
++		led-status-blue {
++			label = "pwm:blue:status";
++			pwms = <&led_pwm 1 1000000 0>;
++			active-low;
++			max-brightness = <255>;
++		};
++	};
++
++	led-controller-1 {
++		status = "disabled";
++	};
++};
 diff --git a/arch/arm/dts/stm32mp157c-lxa-tac-gen1.dts b/arch/arm/dts/stm32mp157c-lxa-tac-gen1.dts
 new file mode 100644
 index 000000000000..47b764f13242

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0201-Release-2024.10.0-customers-lxa-tac-20241121-2.patch
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/0201-Release-2024.10.0-customers-lxa-tac-20241121-2.patch
@@ -1,13 +1,13 @@
-From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Fri, 18 Oct 2024 15:31:31 +0200
-Subject: [PATCH] Release 2024.10.0/customers/lxa/tac/20241018-1
+From: Marc Kleine-Budde <mkl@pengutronix.de>
+Date: Thu, 21 Nov 2024 15:49:30 +0100
+Subject: [PATCH] Release 2024.10.0/customers/lxa/tac/20241121-2
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 9ef8ea726d19..4c37ef4b2c58 100644
+index 9ef8ea726d19..c051e4e82e4f 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 9ef8ea726d19..4c37ef4b2c58 100644
  PATCHLEVEL = 10
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20241018-1
++EXTRAVERSION =-20241121-2
  NAME = None
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/patches/series.inc
@@ -1,9 +1,10 @@
 # umpf-base: v2024.10.0
+# umpf-flags: upstreamstatus=insert
 # umpf-name: 2024.10.0/customers/lxa/tac
-# umpf-version: 2024.10.0/customers/lxa/tac/20241018-1
-# umpf-topic: v2024.09.0/topic/tlv
-# umpf-hashinfo: 328855e48bdb9912ed99b13d817f79a90347d494
-# umpf-topic-range: 1f31cde526d4e251da6464cac42ee2252643b972..9a3e1ac02b877ae8383c77541c63c3f232566eec
+# umpf-version: 2024.10.0/customers/lxa/tac/20241121-2
+# umpf-topic: v2024.10.0/topic/tlv
+# umpf-hashinfo: 6d130e9537b785ad42b8bfb6d0d9c91fd70a3eea
+# umpf-topic-range: 1f31cde526d4e251da6464cac42ee2252643b972..3b1c5b6c26759c488ca8aa83e9145972d229eea7
 SRC_URI += "\
   file://patches/0001-scripts-implement-slurp-a-read_file-with-fd-as-argum.patch \
   file://patches/0002-of_path-support-phandles-in-of_find_path.patch \
@@ -17,20 +18,20 @@ SRC_URI += "\
   file://patches/0010-commands-add-TLV-debugging-command.patch \
   file://patches/0011-scripts-add-bareboxtlv-host-target-tool.patch \
   "
-# umpf-topic: v2024.09.0/customers/lxa/tac
-# umpf-hashinfo: 0400cb4b2d51a576d3fe663bbf74a1c3f5858dc3
-# umpf-topic-range: 9a3e1ac02b877ae8383c77541c63c3f232566eec..8f0fd668eb6c040651cffda27e8547108b0f23fe
+# umpf-topic: v2024.10.0/customers/lxa/tac
+# umpf-hashinfo: 1413c76bc3233a8732a51c3010d6a8433e2b7e3a
+# umpf-topic-range: 3b1c5b6c26759c488ca8aa83e9145972d229eea7..df227f29447718518a7bb92954fc4f74aa58d77f
 SRC_URI += "\
   file://patches/0101-boards-add-decoder-for-LXA-TLV-v1-format.patch \
-  file://patches/0102-ARM-stm32mp-add-Linux-Automation-TAC-board.patch \
-  file://patches/0103-ARM-stm32mp-add-Linux-Automation-TAC-Generation-3.patch \
+  file://patches/0102-ARM-dts-stm32-lxa-tac-fix-gen-1-2-boards-and-add-gen.patch \
+  file://patches/0103-ARM-stm32mp-add-Linux-Automation-TAC-board.patch \
   "
-# umpf-release: 2024.10.0/customers/lxa/tac/20241018-1
-# umpf-topic-range: 8f0fd668eb6c040651cffda27e8547108b0f23fe..d34362cdd815c983aa6216d9c011627f03576180
+# umpf-release: 2024.10.0/customers/lxa/tac/20241121-2
+# umpf-topic-range: df227f29447718518a7bb92954fc4f74aa58d77f..be16d68f8fa1f5197557d48c1f0b9f50cc342895
 SRC_URI += "\
-  file://patches/0201-Release-2024.10.0-customers-lxa-tac-20241018-1.patch \
+  file://patches/0201-Release-2024.10.0-customers-lxa-tac-20241121-2.patch \
   "
 UMPF_BASE = "2024.10.0"
-UMPF_VERSION = "20241018-1"
+UMPF_VERSION = "20241121-2"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 # umpf-end


### PR DESCRIPTION
Import the dts changes sent to Linux mainline and clean up the patch stack.

Link: https://patch.msgid.link/20241119-lxa-tac-gen3-v1-0-e0ab0a369372@pengutronix.de