### PR TITLE
meta-lxatac-software: lxatac-image: move git dep to git{hub,lab}-runner

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -40,7 +40,6 @@ IMAGE_INSTALL:append = "\
     evtest \
     fb-test \
     fio \
-    git \
     github-act-runner \
     gitlab-runner \
     gstreamer1.0 \

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
@@ -14,7 +14,7 @@ inherit systemd
 
 GO_IMPORT = "github.com/ChristopherHX/github-act-runner"
 
-RDEPENDS:${PN}:append = "nodejs"
+RDEPENDS:${PN}:append = "git nodejs"
 RDEPENDS:github-act-runner-dev:append = "make bash"
 
 SYSTEMD_SERVICE:${PN} = "github-act-runner.service"

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.8.0.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.8.0.bb
@@ -1,3 +1,0 @@
-require github-act-runner.inc
-
-SRCREV = "8d74b24282009d31757b94f7ddb9272aeec90e05"

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.9.0.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.9.0.bb
@@ -1,0 +1,3 @@
+require github-act-runner.inc
+
+SRCREV = "5e5a7b6cc4c674adcdc2e771ecc81d1d257fc674"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
@@ -9,6 +9,7 @@ SRC_URI:append = " file://gitlab-runner.service "
 GO_IMPORT = "gitlab.com/gitlab-org/gitlab-runner"
 GO_INSTALL = "${GO_IMPORT}"
 
+RDEPENDS:${PN}:append = "git"
 RDEPENDS:gitlab-runner-dev = "bash"
 
 inherit go-mod

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_17.3.1.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_17.3.1.bb
@@ -1,4 +1,0 @@
-require gitlab-runner.inc
-
-SRC_URI = "git://gitlab.com/gitlab-org/gitlab-runner.git;branch=17-3-stable;protocol=https"
-SRCREV = "66269445606da32c52be605feba6d70fc1a8fb0d"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_17.5.4.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_17.5.4.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRC_URI = "git://gitlab.com/gitlab-org/gitlab-runner.git;branch=17-5-stable;protocol=https"
+SRCREV = "d8d88d9e25349cfb7eefdc9a55f49eab794bb27a"


### PR DESCRIPTION
The intent behind having `git` on the TAC is not for a user to install software or similar.
We only have `git` on the TAC because the GitHub and GitLab action runner software uses it.

Make this more clear by setting the RDEPENDs appropriately.

---

While at it I've also noticed that there were new releases available for both packages, so I went ahead and updated them.
The changelogs did not indicate any relevant changes (to me).