### PR TITLE
meta-lxatac-bsp: linux: add dwc2 patch that fixes device freeze as gadget

### DIFF
--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0101-usb-dwc2-also-exit-clock_gating-when-stopping-udc-wh.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0101-usb-dwc2-also-exit-clock_gating-when-stopping-udc-wh.patch
@@ -1,0 +1,36 @@
+From: Michael Grzeschik <m.grzeschik@pengutronix.de>
+Date: Thu, 17 Apr 2025 18:58:23 +0200
+Subject: [PATCH] usb: dwc2: also exit clock_gating when stopping udc while
+ suspended
+
+It is possible that the gadget will be disabled, while the udc is
+suspended. When enabling the udc in that case, the clock gating
+will not be enabled again. Leaving the phy unclocked. Even when the
+udc is not enabled, connecting this powered but not clocked phy leads
+to enumeration errors on the host side.
+
+To ensure that the clock gating will be in an valid state, we ensure
+that the clock gating will be enabled before stopping the udc.
+
+Signed-off-by: Michael Grzeschik <m.grzeschik@pengutronix.de>
+---
+ drivers/usb/dwc2/gadget.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/usb/dwc2/gadget.c b/drivers/usb/dwc2/gadget.c
+index bd4c788f03bc..d3d0d75ab1f5 100644
+--- a/drivers/usb/dwc2/gadget.c
++++ b/drivers/usb/dwc2/gadget.c
+@@ -4604,6 +4604,12 @@ static int dwc2_hsotg_udc_stop(struct usb_gadget *gadget)
+ 	if (!hsotg)
+ 		return -ENODEV;
+ 
++	/* Exit clock gating when driver is stopped. */
++	if (hsotg->params.power_down == DWC2_POWER_DOWN_PARAM_NONE &&
++	    hsotg->bus_suspended && !hsotg->params.no_clock_gating) {
++		dwc2_gadget_exit_clock_gating(hsotg, 0);
++	}
++
+ 	/* all endpoints should be shutdown */
+ 	for (ep = 1; ep < hsotg->num_of_eps; ep++) {
+ 		if (hsotg->eps_in[ep])

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0201-Release-6.14-customers-lxa-lxatac-20250422-1.patch
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/0201-Release-6.14-customers-lxa-lxatac-20250422-1.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Leonard=20G=C3=B6hrs?= <l.goehrs@pengutronix.de>
-Date: Tue, 25 Mar 2025 07:04:32 +0100
-Subject: [PATCH] Release 6.14/customers/lxa/lxatac/20250325-1
+Date: Tue, 22 Apr 2025 07:33:49 +0200
+Subject: [PATCH] Release 6.14/customers/lxa/lxatac/20250422-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 8b6764d44a61..d9d4e56d1da2 100644
+index 8b6764d44a61..915fd0741dbd 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 8b6764d44a61..d9d4e56d1da2 100644
  PATCHLEVEL = 14
  SUBLEVEL = 0
 -EXTRAVERSION =
-+EXTRAVERSION =-20250325-1
++EXTRAVERSION =-20250422-1
  NAME = Baby Opossum Posse
  
  # *DOCUMENTATION*

--- a/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
+++ b/meta-lxatac-bsp/recipes-kernel/linux/files/patches/series.inc
@@ -1,19 +1,25 @@
 # umpf-base: v6.14
 # umpf-name: 6.14/customers/lxa/lxatac
-# umpf-version: 6.14/customers/lxa/lxatac/20250325-1
+# umpf-version: 6.14/customers/lxa/lxatac/20250422-1
 # umpf-topic: v6.11/topic/reproducible-build
 # umpf-hashinfo: d6ed6f191343a77bfe41d7436b51dffe8bcac441
 # umpf-topic-range: 38fec10eb60d687e30c8c6b5420d86e8149f7557..0df0ed370001fa8e89b05a4171dec57458075fa6
 SRC_URI += "\
   file://patches/0001-ARM-Don-t-mention-the-full-path-of-the-source-direct.patch \
   "
-# umpf-release: 6.14/customers/lxa/lxatac/20250325-1
-# umpf-topic-range: 0df0ed370001fa8e89b05a4171dec57458075fa6..a376cc6220bf4e6db412dfee2cdafe70805f5c79
+# umpf-topic: v6.14/topic/dwc2_clock_gating
+# umpf-hashinfo: c1c67a4b104b8eb5a959a04554689c4e927307a6
+# umpf-topic-range: 0df0ed370001fa8e89b05a4171dec57458075fa6..3d75e99fdc24c874f64364d6ddd0761c60f43244
 SRC_URI += "\
-  file://patches/0101-Release-6.14-customers-lxa-lxatac-20250325-1.patch \
+  file://patches/0101-usb-dwc2-also-exit-clock_gating-when-stopping-udc-wh.patch \
+  "
+# umpf-release: 6.14/customers/lxa/lxatac/20250422-1
+# umpf-topic-range: 3d75e99fdc24c874f64364d6ddd0761c60f43244..d954ed78834876ace0f3d430a537b557915e64fb
+SRC_URI += "\
+  file://patches/0201-Release-6.14-customers-lxa-lxatac-20250422-1.patch \
   "
 UMPF_BASE = "6.14"
-UMPF_VERSION = "20250325-1"
+UMPF_VERSION = "20250422-1"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 LINUX_VERSION = "${UMPF_BASE}"
 # umpf-end


### PR DESCRIPTION
This integrates a patch by @mgrzeschik, which should fix an issue with the TAC running as USB Gadget (e.g. as storage gadget, emulating a USB thumb drive), where some sequences of operations may lead to the whole device freezing and subsequently being rebooted by the watchdog.

TODO before merging:

- [x] This PR is based on https://github.com/linux-automation/meta-lxatac/pull/234, which should be merged first.

@mgrzeschik: it looks like you are not in in the linux-automation organization, so I can not mark you as reviewer. Could you give this PR a look anyways?