### PR TITLE
Software fixes for 25.04 release

### DIFF
--- a/meta-lxatac-bsp/conf/machine/lxatac.conf
+++ b/meta-lxatac-bsp/conf/machine/lxatac.conf
@@ -17,6 +17,7 @@ SERIAL_CONSOLES = "115200;ttySTM0"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-lxatac"
 PREFERRED_PROVIDER_virtual/bootloader ?= "barebox"
+PREFERRED_VERSION_trusted-firmware-a ?= "2.10%"
 
 BAREBOX_IMAGE = "barebox-stm32mp157c-lxa-tac.img"
 

--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
@@ -16,6 +16,14 @@ mkdir -p "${DST_LINK_FILE_BASE}"
 # systemd.hostname= kernel commandline and interpreted by init.
 # -------------------------------------------------------------
 
+if grep -q "^localhost\$" /etc/hostname
+then
+    # There was an error where "localhost" may have been persisted to
+    # /etc/hostname during bringup instead of lxatac-$SERIAL.
+    # Remove /etc/hostname if that is the case.
+    rm /etc/hostname
+fi
+
 HOSTNAME="$(hostname)"
 
 if [[ "${HOSTNAME}" != "localhost" ]] && [[ ! -e /etc/hostname ]]

--- a/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
+++ b/meta-lxatac-bsp/recipes-core/lxatac-factory-data/files/lxatac-factory-data.sh
@@ -16,9 +16,11 @@ mkdir -p "${DST_LINK_FILE_BASE}"
 # systemd.hostname= kernel commandline and interpreted by init.
 # -------------------------------------------------------------
 
-if [[ ! -e /etc/hostname ]]
+HOSTNAME="$(hostname)"
+
+if [[ "${HOSTNAME}" != "localhost" ]] && [[ ! -e /etc/hostname ]]
 then
-    hostname > /etc/hostname
+    echo "${HOSTNAME}" > /etc/hostname
 fi
 
 # Read Factory Data passed to us by barebox via the devicetree

--- a/meta-lxatac-software/files/group
+++ b/meta-lxatac-software/files/group
@@ -1,4 +1,5 @@
 root:x:0:
+gpio:x:981:
 systemd-journal-upload:x:982:
 pulse:x:983:
 avahi-autoipd:x:984:

--- a/meta-lxatac-software/files/passwd
+++ b/meta-lxatac-software/files/passwd
@@ -1,4 +1,5 @@
 root:x:0:0
+gpio-manager:x:981:981
 pulse:x:983:983
 avahi-autoipd:x:984:984
 systemd-journal-upload:x:988:982

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -31,7 +31,6 @@ IMAGE_INSTALL:append = "\
     chrony \
     chronyc \
     container-control \
-    crun \
     curl \
     devmem2 \
     dfu-util \

--- a/meta-lxatac-software/recipes-core/lxatac-profile/lxatac-profile/01-labgrid.sh
+++ b/meta-lxatac-software/recipes-core/lxatac-profile/lxatac-profile/01-labgrid.sh
@@ -2,4 +2,4 @@
 
 # export labgrid environment to be used with labgrid-client on the lxatac
 source /etc/labgrid/environment
-export LG_CROSSBAR="ws://${LABGRID_COORDINATOR_IP:?}:${LABGRID_COORDINATOR_PORT:?}/ws"
+export LG_COORDINATOR="${LABGRID_COORDINATOR_IP:?}:${LABGRID_COORDINATOR_PORT:?}"


### PR DESCRIPTION
These are some small fixes that came up while preparing the `styhead` and subsequent `walnascar` Yocto release upgrades.
They are however not specific to these software releases, so we can (and should) already merge them into the `scarthgap` branch.