### PR TITLE
meta-lxatac-software: lxatac-core-image-base: add iproute2-bridge

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -52,6 +52,7 @@ IMAGE_INSTALL:append = "\
     iperf3 \
     iproute2 \
     iproute2-bash-completion \
+    iproute2-bridge \
     iproute2-devlink \
     iproute2-ifstat \
     iproute2-ip \

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -17,9 +17,9 @@ IMAGE_LINGUAS = "en-us"
 
 IMAGE_INSTALL:append = "\
     alsa-utils \
+    android-tools \
     atftp \
     atftpd \
-    android-tools \
     avahi-utils \
     barebox-tools \
     bcu \


### PR DESCRIPTION
This installs the `bridge` command, which we use in our testsuite to check the correct setup of the `tac-bridge` network interface.
