### PR TITLE
meta-lxatac-software: distro: tacos: update version to v25.04

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "24.09+dev"
+DISTRO_VERSION = "25.04"
 DISTRO_CODENAME = "tacos-walnascar"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -80,5 +80,4 @@ BB_HASHSERVE ??= "auto"
 # recommend ipk package management - make sure to comment or set it in local.conf.sample
 PACKAGE_CLASSES ?= "package_ipk"
 
-LABGRID_USE_DEVEL_VERSION ?= "1"
 RAUC_USE_DEVEL_VERSION = "1"

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -79,5 +79,3 @@ BB_HASHSERVE ??= "auto"
 
 # recommend ipk package management - make sure to comment or set it in local.conf.sample
 PACKAGE_CLASSES ?= "package_ipk"
-
-RAUC_USE_DEVEL_VERSION = "1"


### PR DESCRIPTION
Some last-minute version updates / switches to released software versions, followed by a version number update to 25.04.

Here is some text that we can use for the release notes:

---

It's time to spin a new release.

# Notable Changes since v24.09:

  - Update to labgrid 25.0 which uses gRPC instead of crossbar/autobahn for communication between client/exporter and coordinator.
    This is a *breaking change*. See the Breaking Changes section below for upgrade instructions.
    The LXA TAC images now also contain the `labgrid-coordinator`, which means you could now build a fully self-contained "distributed" labgrid setup (exporter, coordinator, client) on a single TAC.
  - Update yocto version from scarthgap to walnascar
  - Update Linux Kernel from 6.10 to 6.14.
  - Enable more USB Bluetooth and WiFi drivers and make them available via NetworkManager.
  - Fix an issue where the TAC would freeze when performing some USB gadget operations.
  - Update various pieces of included software and switch to mainlined bitbake recipes where available.

# Breaking Changes:

(This is an excerpt from the Labgrid [25.0 release notes](https://github.com/labgrid-project/labgrid/releases/tag/v25.0))

Due to the gRPC migration, 25.0 includes the following breaking changes:

- The labgrid environment config option `crossbar_url` was replaced by `coordinator_address`. The environment variable `LG_CROSSBAR` was replaced by `LG_COORDINATOR`¹.
- The labgrid environment config option `crossbar_realm` is now obsolete as well as the environment variable `LG_CROSSBAR_REALM`.
- The coordinator is available as `labgrid-coordinator` (instead of `crossbar start`). No additional configuration file is required.
- The systemd services in contrib/systemd/ were updated¹.

To update your deployment to 25.0, you'll need to:

- Update the coordinator, all clients and all exporters to the new release.
- Start `labgrid-coordinator` directly (instead of via the crossbar configuration file)². If needed, you can set the listening address using the --listen option.
- Update any existing client and exporter configuration by replacing the crossbar URL with the coordinator address.¹

1) Unless you are using a customized setup this is already handled on the TAC for you. You may however have to update the rest of your labgrid deployment.
2) This step has to be performed on the host where your coordinator runs, which is most likely not the TAC.

---

**PS:** we are a bit late for this April (25.04) release, but decided to keep the naming schema since we aim to follow the yocto release schedule (April and October).