### PR TITLE
meta-lxatac-software: distro: tacos: start v25.04 devel phase

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "25.04"
+DISTRO_VERSION = "25.04+dev"
 DISTRO_CODENAME = "tacos-walnascar"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
Now that we have a v25.04 stable release we need to start denoting everything based on it as +dev again.

TODO before merging:

- [x] Actually tag a 25.04 release.