### PR TITLE
python3-labgrid: update to new version

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -99,6 +99,7 @@ IMAGE_INSTALL:append = "\
     pps-tools \
     pv \
     python3-labgrid \
+    python3-labgrid-coordinator \
     python3-lxa-iobus \
     python3-pygobject \
     python3-usbmuxctl \

--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid_%.bbappend
@@ -4,6 +4,8 @@ SRC_URI += "file://userconfig.yaml \
             file://labgrid.conf \
             "
 
+SYSTEMD_AUTO_ENABLE:${PN}-coordinator = "disable"
+
 do_install:append() {
     # The userconfig.yaml is migrated via rauc hook between installs.
     # Deploy a copy of the file so that users can go back to a default config


### PR DESCRIPTION
Which includes a systemd service for coordinator, which we want to have installed, but not active.

Rebase after https://github.com/labgrid-project/meta-labgrid/pull/66 is approved with new meta-labgrid revision. Do not merge beforehand. Just here to not forget about it.