### PR TITLE
lxatac-core-image-base: add Snagboot and Qualcomm downloader

### DIFF
--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -101,6 +101,7 @@ IMAGE_INSTALL:append = "\
     python3-labgrid \
     python3-lxa-iobus \
     python3-pygobject \
+    python3-snagboot \
     python3-usbmuxctl \
     python3-usbsdmux \
     python3-venv \

--- a/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
+++ b/meta-lxatac-software/recipes-core/images/lxatac-core-image-base.bb
@@ -104,6 +104,7 @@ IMAGE_INSTALL:append = "\
     python3-usbmuxctl \
     python3-usbsdmux \
     python3-venv \
+    qdl \
     rauc \
     ripgrep \
     rkdeveloptool \

--- a/meta-lxatac-software/recipes-devtools/qdl/qdl_git.bb
+++ b/meta-lxatac-software/recipes-devtools/qdl/qdl_git.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Qualcomm DownLoader flashing tool"
+DESCRIPTION = "Communicate with Qualcomm SoCs to upload new software or \
+dump memory"
+HOMEPAGE = "https://github.com/linux-msm/qdl.git"
+SECTION = "devel"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=da6bfde9cb5bc5120a51775381f6edf1"
+
+DEPENDS = "libxml2 libusb1"
+
+inherit pkgconfig
+
+SRCREV = "5db7794e9fdb73ed0c45384026cd8a62b5fff786"
+SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
+
+PV = "2.1+${SRCREV}"
+
+S = "${WORKDIR}/git"
+
+do_install () {
+    oe_runmake install DESTDIR=${D} prefix=${prefix}
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
There is no Labgrid support for either yet, but we need to start somewhere, so let's add them to the image for command-line usage.