### PR TITLE
ci: larger timeouts, fewer dependabot runs and cache dependabot sstate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: build
     runs-on: [self-hosted, forrest, build]
+    timeout-minutes: 720
     if: ${{ vars.HAS_BUILD_RUNNER || github.repository == 'linux-automation/meta-lxatac' }}
     steps:
       - name: Check out the repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache Data
         env:
           CACHE_KEY: ${{ secrets.YOCTO_CACHE_KEY }}
-        if: ${{ github.ref_protected && env.CACHE_KEY }}
+        if: ${{ env.CACHE_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$CACHE_KEY" >> ~/.ssh/id_ed25519


### PR DESCRIPTION
This does three things that should prevent a situation like we have now, where [build jobs on our main branch](https://github.com/linux-automation/meta-lxatac/actions/runs/15267147720/job/42934774427) run into timeout:

- Upload the `sstate` generated in Dependabot pull requests. This way we do not have to re-build again once the PR is merged.
- Give the jobs more time (6h -> 12h)¹.
- ~~Update the meta-* layers on a monthly basis instead of a weekly basis.~~

---

¹) I know that these numbers sound crazy, but we _do_ build quite a lot of stuff into the LXA TAC images and the build time has to account for rebuilds from scratch, possibly with other jobs running on the host at the same time.