### PR TITLE
meta-labgrid: switch to the walnascar branch from master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "meta-labgrid"]
 	path = meta-labgrid
 	url = https://github.com/labgrid-project/meta-labgrid.git
-	branch = master
+	branch = walnascar
 [submodule "meta-virtualization"]
 	path = meta-virtualization
 	url = https://github.com/lgirdk/meta-virtualization.git


### PR DESCRIPTION
In commit 548cafd ("poky/meta-*: update walnascar/master branches") the meta-labgrid submodule has been the only one to use the master branch instead of a walnascar branch, because back then there was no walnascar branch and the master branch was compatible with the walnascar release.

Both of these statements are no longer true. There ist a walnascar branch now and the master branch is no longer compatible with walnascar.

Use the new walnascar branch.