### PR TITLE
meta-lxatac-bsp: barebox-tools: install rk-usb-loader

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools.bbappend
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools.bbappend
@@ -1,0 +1,1 @@
+BAREBOX_TOOLS:append = " rk-usb-loader"


### PR DESCRIPTION
The rk-usb-loader is already enabled in the hosttools_defconfig and targettools_defconfig and compiled by barebox-tools.

Add it to the BAREBOX_TOOLS list to actually install it.