### PR TITLE
meta-lxatac-software: distro: tacos: update version to v25.09

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "25.04+dev"
+DISTRO_VERSION = "25.09"
 DISTRO_CODENAME = "tacos-walnascar"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
It's time to spin a new release.

Notable Changes since v25.04:

  - Added the Qualcomm Downloader (qdl) package.
  - Added snagboot, the generic recovery and reflashing tool.
  - Update from Linux version 6.14 to 6.17.
  - Update from barebox 2024.10 to patch free 2025.09.
  - Update various pieces of included software.

All in all not necessarily an exiting release, but hopefully a smooth and steady one.

PS: as is tradition we are a bit late for our own release schedule. This means we are releasing this September (25.09) release in October.