### PR TITLE
Late software updates for 25.09 release

### DIFF
--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.3.1.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.3.1.bb
@@ -1,4 +1,0 @@
-require gitlab-runner.inc
-
-SRCBRANCH = "18-3-stable"
-SRCREV = "5a021a1c14edadc683ee4b1f0a00182ec3ee636a"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.4.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.4.0.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRCBRANCH = "18-4-stable"
+SRCREV = "139a0ac033907890894642625cdfabf215c614fd"

--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -4,7 +4,7 @@ inherit cargo-update-recipe-crates
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
-SRCREV = "71aae7abee147883b9c6e19b7119800c1b395b90"
+SRCREV = "1c2f16f8b4041b31cee702677630298614c23feb"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "71aae7abee147883b9c6e19b7119800c1b395b90"
+SRCREV = "1c2f16f8b4041b31cee702677630298614c23feb"
 
 S = "${WORKDIR}/sources/git/web"
 UNPACKDIR = "${WORKDIR}/sources"


### PR DESCRIPTION
A [run of the updater script](https://github.com/hnez/meta-lxatac/pull/8) proposed in #296 shows that a few more upstream changes snuck in since I have opened #297.
We might as well apply them before spinning the new release.