### PR TITLE
meta-lxatac-bsp: barebox: fix framebuffer console writes after update

### DIFF
--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-a
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-a
@@ -5,11 +5,11 @@ led led-status-red 0
 led led-status-green 252
 led led-status-blue 97
 
-echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-a ..."
+echo -a /dev/fbconsole0-1 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-a ..."
 
 boot -v mmc1.root-a
 
 # Show splash screen with red background on error
 splash -b 0xffcd0000 /env/data/splash.png
 
-echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root-a!"
+echo -a /dev/fbconsole0-1 -e -n "\e[17;10H\e[41mError booting root-a!"

--- a/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-b
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/files/lxatac/env/boot/root-b
@@ -5,11 +5,11 @@ led led-status-red 0
 led led-status-green 252
 led led-status-blue 97
 
-echo -a /dev/fbconsole0 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-b ..."
+echo -a /dev/fbconsole0-1 -e -n "\e[?25l\e[1;1H\e[37;1mBooting root-b ..."
 
 boot -v mmc1.root-b
 
 # Show splash screen with red background on error
 splash -b 0xffcd0000 /env/data/splash.png
 
-echo -a /dev/fbconsole0 -e -n "\e[17;10H\e[41mError booting root-b!"
+echo -a /dev/fbconsole0-1 -e -n "\e[17;10H\e[41mError booting root-b!"


### PR DESCRIPTION
The device file has changed its name after some past update:
```
  barebox@Linux Automation Test Automation Controller (TAC) Gen 3:/ ls -l /dev/fbconsole0-1
  c-w-------              0 /dev/fbconsole0-1
  barebox@Linux Automation Test Automation Controller (TAC) Gen 3:/ devinfo fbconsole0
  Bus: platform
  Parent: fb0
  Parameters:
    active:  (type: string)
    font: VGA8x16 (type: enum)
    margin.bottom: 0 (type: uint32)
    margin.left: 0 (type: uint32)
    margin.right: 0 (type: uint32)
    margin.top: 0 (type: uint32)
    rotation: 0 (type: enum) (values: "0", "90", "180", "270")
```
I still need to determine when this happened, but for now restore the display output by using the new name.