### PR TITLE
meta-lxatac-software: tac-gadget: fix wrong MAC addr in ethernet-storage

### DIFF
--- a/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-storage.sh
+++ b/meta-lxatac-software/recipes-devtools/tac-gadget/files/gadget-ethernet-storage.sh
@@ -17,8 +17,8 @@ setup_gadget
 
 # Set up ethernet
 mkdir "${DEVDIR}/functions/ecm.usb0"
-echo "${HOST_MAC:?} > ${DEVDIR}/functions/ecm.usb0/host_addr"
-echo "${DEV_MAC:?} > ${DEVDIR}/functions/ecm.usb0/dev_addr"
+echo "${HOST_MAC:?}" > "${DEVDIR}/functions/ecm.usb0/host_addr"
+echo "${DEV_MAC:?}" > "${DEVDIR}/functions/ecm.usb0/dev_addr"
 ln -s "${DEVDIR}/functions/ecm.usb0" "${DEVDIR}/configs/c.1"
 
 # Set up storage


### PR DESCRIPTION
Commit 4f825d9 ("meta-lxatac-software: tac-gadget: fix shellcheck warnings in helper scripts") added wrong quoting of these echo calls, making them ineffective.

This results in a random MAC address being used on the USB network interface.

Fixes: 4f825d9 ("meta-lxatac-software: tac-gadget: fix shellcheck ...")