### PR TITLE
Software Updates 20.10.2025

### DIFF
--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.4.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.4.0.bb
@@ -1,4 +1,0 @@
-require gitlab-runner.inc
-
-SRCBRANCH = "18-4-stable"
-SRCREV = "139a0ac033907890894642625cdfabf215c614fd"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.5.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.5.0.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRCBRANCH = "18-5-stable"
+SRCREV = "bda84871762de5fb1573f4495940e044e8a5a010"

--- a/meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend
+++ b/meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend
@@ -1,4 +1,4 @@
-PV = "1.1.120"
-SRCREV = "394a01f742e640c3aff0e87d4e0529e57d977ec5"
+PV = "1.1.121"
+SRCREV = "523d6fd8c75e8c82a987ec23c7674ec12990762a"
 
 SRC_URI:remove = "file://0001-CMakeLists-do-not-use-vendored-libcurl.patch"


### PR DESCRIPTION
This is a backport of this automatic update PR: https://github.com/hnez/meta-lxatac/pull/9 minus the ripgrep update, which does not build with the rustc version in walnascar. The ripgrep update was split out into PR #313.