### PR TITLE
meta-lxatac-software: lxatac-core-bundle-base: accept empty migrate.d dir

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -exu -o pipefail
+shopt -s nullglob
 
 EXTRA_MIGRATE_LISTS_DIR="/etc/rauc/migrate.d"
 CERT_AVAILABLE_DIR="${RAUC_SLOT_MOUNT_POINT:?}/etc/rauc/certificates-available"
@@ -47,10 +48,6 @@ function migrate () {
 }
 
 function process_migrate_lists () {
-	if [[ ! -d "${EXTRA_MIGRATE_LISTS_DIR}" ]]; then
-		return
-	fi
-
 	for migrate_list in "${EXTRA_MIGRATE_LISTS_DIR}"/*.conf; do
 		# Migrate files in the list line by line
 		while read -r line; do


### PR DESCRIPTION
Looks like I have shot myself in the foot again with a shell script.

---

Prior to this patch the part of the hook script that handles migration of user-specified files will fail if the `/etc/rauc/migrate.d` directory exists but does not contain any `*.conf` files.

Make sure that the glob expands to nothing instead of the string `/etc/rauc/migrate.d/*.conf` in this case by setting the `nullglob` option. This also removes the need for the ineffective check for the existance of the `/etc/rauc/migrate.d` directory.