### PR TITLE
meta-lxatac-software: labgrid-exporter: Add HTTP and TFTP provider

### DIFF
--- a/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/meta-lxatac-software/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -103,3 +103,17 @@ lxatac-usb-ports-p{{idx}}.{{if}}:
       '@ID_PATH': '{{sysfs}}:1.{{if}}'
 {% endfor %}
 {% endfor %}
+
+
+## Internal TFTP Server
+tftp:
+  TFTPProvider:
+    internal: "/srv/tftp/"
+    external: "/"
+
+## Internal HTTP Server
+http:
+  HTTPProvider:
+    internal: "/srv/www/"
+    external: "http://{{hostname}}/srv/"
+


### PR DESCRIPTION
meta-lxatac already ships with a TFTP-server (atftpd) and a HTTP-server (in tacd).
Let's export these as resources in labgrid.