### PR TITLE
meta-lxatac-software: gitlab-runner: update from 18.5.0 to 18.6.3

### DIFF
--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.5.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.5.0.bb
@@ -1,4 +1,0 @@
-require gitlab-runner.inc
-
-SRCBRANCH = "18-5-stable"
-SRCREV = "bda84871762de5fb1573f4495940e044e8a5a010"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.6.3.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.6.3.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRCBRANCH = "18-6-stable"
+SRCREV = "dbac4904553947d823cf632ac928023ec2c9a987"


### PR DESCRIPTION
Just a regular update. I could not identify any new killer features.