### PR TITLE
meta-lxatac-{bsp,software}: make sure all `:append`s have a leading space

### DIFF
--- a/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lxatac-bsp/recipes-core/systemd/systemd_%.bbappend
@@ -1,6 +1,6 @@
-RRECOMMENDS:${PN}:append = "less"
+RRECOMMENDS:${PN}:append = " less"
 # Enable lz4 and seccomp for systemd
-PACKAGECONFIG:append = "lz4"
+PACKAGECONFIG:append = " lz4"
 PACKAGECONFIG:remove = "networkd"
 
 # Re-enable LLMNR (but not mDNS, which is handled by avahi),

--- a/meta-lxatac-software/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-lxatac-software/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,3 +1,3 @@
 # The terminal user interface is the one we document in the manual.
 # Make sure it is installed.
-PACKAGECONFIG:append = "nmtui"
+PACKAGECONFIG:append = " nmtui"

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner.inc
@@ -16,8 +16,8 @@ inherit systemd
 
 GO_IMPORT = "github.com/ChristopherHX/github-act-runner"
 
-RDEPENDS:${PN}:append = "git nodejs"
-RDEPENDS:github-act-runner-dev:append = "make bash"
+RDEPENDS:${PN}:append = " git nodejs"
+RDEPENDS:github-act-runner-dev:append = " make bash"
 
 SYSTEMD_SERVICE:${PN} = "github-act-runner.service"
 

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner.inc
@@ -12,7 +12,7 @@ SRC_URI = " \
     file://gitlab-runner.service \
     "
 
-RDEPENDS:${PN}:append = "git"
+RDEPENDS:${PN}:append = " git"
 RDEPENDS:gitlab-runner-dev = "bash"
 
 inherit go-mod


### PR DESCRIPTION
The leading space is only inserted automatically for `+=`, not for `:append =`  which is not confusing at all.

Thanks to @Bastian-Krause for giving me a tip about this.