### PR TITLE
Software Updates 05.01.2026

### DIFF
--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.12.0.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.12.0.bb
@@ -1,3 +1,0 @@
-require github-act-runner.inc
-
-SRCREV = "1636dd12fe3f21f235a673aef773eaf2853b6ce2"

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.12.2.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.12.2.bb
@@ -1,0 +1,3 @@
+require github-act-runner.inc
+
+SRCREV = "f0ff9b6abcbb4b342954a4d02319d5b1a8afb171"

--- a/meta-lxatac-software/recipes-devtools/qdl/qdl_2.4.bb
+++ b/meta-lxatac-software/recipes-devtools/qdl/qdl_2.4.bb
@@ -12,7 +12,7 @@ DEPENDS = "libxml2 libusb1"
 inherit pkgconfig
 
 SRC_URI = "git://github.com/linux-msm/${BPN}.git;branch=master;protocol=https"
-SRCREV = "a601db1868bcda454a77b6769ca9efac3b0a114c"
+SRCREV = "6eeb866b1503a9219258edbdb72fcd478c20b2d7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This is a backport of this automatic update PR: https://github.com/hnez/meta-lxatac/pull/17 minus the bcu and imx-uuu updates, which are only pre-releases according to their GitHub release pages and the gitlab-runner update which requires a go compiler version not present in walnascar. The gitlab-runner update was split into the draft PR #328.