### PR TITLE
meta-lxatac-software: gitlab-runner: update from 18.6.3 to 18.7.1

### DIFF
--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.6.3.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.6.3.bb
@@ -1,4 +1,0 @@
-require gitlab-runner.inc
-
-SRCBRANCH = "18-6-stable"
-SRCREV = "dbac4904553947d823cf632ac928023ec2c9a987"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.8.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.8.0.bb
@@ -1,0 +1,4 @@
+require gitlab-runner.inc
+
+SRCBRANCH = "18-8-stable"
+SRCREV = "9ffb4aa066204dc1b5f80b3043c30936002434fb"


### PR DESCRIPTION
This does not build currently, because our version of the go compiler (1.24.6)) is too old to build the new gitlab-runner release (which requires at least 1.24.11).
This update can be applied once we leave the walnascar release behind.
