### PR TITLE
meta-virtualization: switch to correct upstream repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	branch = walnascar
 [submodule "meta-virtualization"]
 	path = meta-virtualization
-	url = https://github.com/lgirdk/meta-virtualization.git
+	url = https://git.yoctoproject.org/meta-virtualization
 	branch = walnascar
 [submodule "poky"]
 	path = poky


### PR DESCRIPTION
We used a fork which is no longer updated, so switch to the correct upstream repository.