### PR TITLE
tools: update: add a script that automatically updates bb files

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,87 @@
+name: update recipes
+
+on:
+  schedule:
+    - cron: '10 21 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: update recipes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v5
+
+      - name: Configure git
+        run: |
+          git config user.email "info@linux-automation.com"
+          git config user.name "Recipe Updater Bot"
+
+      - name: Create a new branch
+        run: git checkout -b "update/recipes-$(date +%Y%m%d)"
+
+      - name: Run update script
+        run: python3 -u tools/update/update.py tools/update/recipes.yaml
+
+      - name: Commit changes to recipes
+        id: recipe-commit
+        run: |
+          git add .
+          git commit --signoff --message="Recipe updates for $(date +%Y-%m-%d)"
+        continue-on-error: true
+
+      - name: Update rust and go dependencies
+        if: ${{ steps.recipe-commit.outcome == 'success' }}
+        run: |
+          # Set up the system for use with bitbake
+          sudo apt-get install chrpath diffstat
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+          # Get meta layers
+          git submodule init
+          git submodule update --single-branch --depth 1
+
+          # Configure bitbake to use pre-built sstate
+          mkdir -p build/conf
+          cat <<EOF > build/conf/auto.conf
+          # Use the shared sstate cache
+          SSTATE_MIRRORS = "file://.* https://github-runner.pengutronix.de/sstate-cache/PATH"
+
+          # As long as we do not have a global hash equivalence server running together
+          # with the sstate mirror, using a (local) hash equivalence server will be
+          # ineffective as hashes match less often. Disable hash equivalence for now.
+          BB_SIGNATURE_HANDLER = "OEBasicHash"
+          BB_HASHSERVE = ""
+
+          # Prefer fast compression over small file size
+          OPKGBUILDCMD = "opkg-build -Z gzip -a -1n"
+          EOF
+
+          source oe-init-build-env
+
+          # Update the -crates.inc files
+          bitbake -c update_crates bottom tacd ripgrep
+
+          # Update the -go-mods.inc and -licenses.inc files
+          bitbake -c update_modules github-act-runner gitlab-runner
+
+      - name: Commit changes to rust and go dependencies
+        if: ${{ steps.recipe-commit.outcome == 'success' }}
+        run: |
+          git add .
+          git commit --signoff --message="Rust and Go dependency update for $(date +%Y-%m-%d)"
+        continue-on-error: true
+
+      - name: Push changes upstream
+        if: ${{ steps.recipe-commit.outcome == 'success' }}
+        run: git push --set-upstream origin "$(git branch --show-current)"
+
+      - name: Create pull request
+        if: ${{ steps.recipe-commit.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr create --base "${{ github.ref_name }}" --fill-first

--- a/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools.bbappend
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools.bbappend
@@ -1,3 +1,4 @@
+# Release commit created 0000-00-00 00:00:00 +0000
 PV = "2025.09.0"
 SRC_URI[sha256sum] = "7df1aa47bb7bf1763a729137ac773e69a4052812af094475d739fc63a9295f0d"
 

--- a/meta-lxatac-bsp/recipes-bsp/barebox/barebox.bbappend
+++ b/meta-lxatac-bsp/recipes-bsp/barebox/barebox.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
     file://env \
 "
 
+# Release commit created 0000-00-00 00:00:00 +0000
 PV = "2025.11.0"
 SRC_URI[sha256sum] = "6a487eb975169ef4ecc912d3e1044fb9ee4aa164c21d4db960a384a60d0914f6"
 

--- a/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.13.0.bb
+++ b/meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_0.13.0.bb
@@ -9,8 +9,9 @@ SRC_URI = "\
     file://github-act-runner.service \
     "
 
-SRCBRANCH = "main"
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "c934667526f602e5732e7072fcd53b36cf044e37"
+SRCBRANCH = "main"
 
 RDEPENDS:${PN}:append = " git nodejs"
 RDEPENDS:github-act-runner-dev:append = " make bash"

--- a/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.8.0.bb
+++ b/meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_18.8.0.bb
@@ -9,6 +9,7 @@ SRC_URI = "\
     file://gitlab-runner.service \
     "
 
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "b667bb8c9bb7a9abdc82991a8c04765b7ce376ee"
 SRCBRANCH = "18-8-stable"
 

--- a/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool_git.bb
+++ b/meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool_git.bb
@@ -10,6 +10,7 @@ SRC_URI = "git://github.com/rockchip-linux/rkdeveloptool.git;protocol=https;bran
            file://0001-Makefile-disable-format-truncation-errors.patch \
            "
 
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "46bb4c073624226c3f05b37b9ecc50bbcf543f5a"
 PV = "1.32+git"
 

--- a/meta-lxatac-software/recipes-rust/bottom/bottom_0.12.3.bb
+++ b/meta-lxatac-software/recipes-rust/bottom/bottom_0.12.3.bb
@@ -1,7 +1,10 @@
 inherit cargo cargo-update-recipe-crates
 
 SRC_URI += "git://github.com/ClementTsang/bottom.git;protocol=https;branch=main;tag=${PV}"
+
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "2f0e9dea99232f0cb116dd1011d9ff1ba9495594"
+
 CARGO_SRC_DIR = ""
 
 # The bottom Cargo.toml strips release builds, why makes it hard to debug.

--- a/meta-lxatac-software/recipes-rust/ripgrep/ripgrep_15.1.0.bb
+++ b/meta-lxatac-software/recipes-rust/ripgrep/ripgrep_15.1.0.bb
@@ -1,7 +1,10 @@
 inherit cargo cargo-update-recipe-crates
 
 SRC_URI += "git://github.com/BurntSushi/ripgrep.git;protocol=https;branch=master;tag=${PV}"
+
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "af60c2de9d85e7f3d81c78601669468cf02dabab"
+
 CARGO_SRC_DIR = ""
 
 LIC_FILES_CHKSUM = " \

--- a/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
+++ b/meta-lxatac-software/recipes-rust/tacd/tacd_git.bb
@@ -4,9 +4,12 @@ inherit cargo-update-recipe-crates
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI += "git://github.com/linux-automation/tacd.git;protocol=https;branch=main"
+
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "1c2f16f8b4041b31cee702677630298614c23feb"
-CARGO_SRC_DIR = ""
 PV = "0.1.0+git${SRCPV}"
+
+CARGO_SRC_DIR = ""
 
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=570a9b3749dd0463a1778803b12a6dce \

--- a/meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend
+++ b/meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend
@@ -1,4 +1,5 @@
-PV = "1.1.121"
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "523d6fd8c75e8c82a987ec23c7674ec12990762a"
+PV = "1.1.121"
 
 SRC_URI:remove = "file://0001-CMakeLists-do-not-use-vendored-libcurl.patch"

--- a/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.233.bb
+++ b/meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_1.5.233.bb
@@ -3,6 +3,8 @@ DESCRIPTION = "Image deployment tool for i.MX chips"
 HOMEPAGE = "https://github.com/NXPmicro/mfgtools"
 
 SRC_URI = "git://github.com/nxp-imx/mfgtools.git;protocol=https;branch=master;tag=uuu_${PV}"
+
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "79ce7d2b2e7459e7b7c94f902d172c30b08884ab"
 
 LICENSE = "BSD-3-Clause"

--- a/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
+++ b/meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb
@@ -8,8 +8,9 @@ LIC_FILES_CHKSUM = " \
     file://../LICENSE;md5=570a9b3749dd0463a1778803b12a6dce \
 "
 
-PV = "0.1.0+git${SRCPV}"
+# Commit created 0000-00-00 00:00:00 +0000
 SRCREV = "1c2f16f8b4041b31cee702677630298614c23feb"
+PV = "0.1.0+git${SRCPV}"
 
 S = "${UNPACKDIR}/${BP}/web"
 

--- a/tools/update/recipes.yaml
+++ b/tools/update/recipes.yaml
@@ -1,0 +1,57 @@
+recipes:
+  - recipe: "meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_$PV.bb"
+    git_tag:
+      url: "https://github.com/ChristopherHX/github-act-runner.git"
+      version_pattern: "^v([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-devtools/gitlab-runner/gitlab-runner_$PV.bb"
+    git_tag:
+      url: "https://gitlab.com/gitlab-org/gitlab-runner.git"
+      version_pattern: "^v([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-devtools/qdl/qdl_$PV.bb"
+    git_tag:
+      url: "https://github.com/linux-msm/qdl.git"
+      version_pattern: "^v([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-devtools/rkdeveloptool/rkdeveloptool_git.bb"
+    git_branch:
+      url: "https://github.com/rockchip-linux/rkdeveloptool.git"
+      branch: master
+
+  - recipe: "meta-lxatac-software/recipes-rust/bottom/bottom_$PV.bb"
+    git_tag:
+      url: "https://github.com/ClementTsang/bottom.git"
+      version_pattern: "^([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-rust/ripgrep/ripgrep_$PV.bb"
+    git_tag:
+      url: "https://github.com/BurntSushi/ripgrep.git"
+      version_pattern: "^([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-rust/tacd/tacd_git.bb"
+    git_branch:
+      url: "https://github.com/linux-automation/tacd.git"
+      branch: main
+
+  - recipe: "meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_$PV.bb"
+    git_tag:
+      url: "https://github.com/nxp-imx/mfgtools.git"
+      version_pattern: "^uuu_([\\d+\\.]*\\d+)$"
+      version_order: semver
+
+  - recipe: "meta-lxatac-software/recipes-webadmin/tacd-webinterface/tacd-webinterface_git.bb"
+    git_branch:
+      url: "https://github.com/linux-automation/tacd.git"
+      branch: main
+
+  - recipe: "meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend"
+    git_tag:
+      url: "https://github.com/nxp-imx/bcu.git"
+      version_pattern: "^bcu_(1\\.1[\\.\\d+]*)$"
+      version_order: semver

--- a/tools/update/recipes.yaml
+++ b/tools/update/recipes.yaml
@@ -1,4 +1,20 @@
 recipes:
+  - recipe: "meta-lxatac-bsp/recipes-bsp/barebox/barebox.bbappend"
+    git_tag:
+      url: "https://github.com/barebox/barebox.git"
+      version_pattern: "^v([\\d+\\.]*\\d+)$"
+      version_order: semver
+    tarball:
+      url: "https://barebox.org/download/barebox-$PV.tar.bz2"
+
+  - recipe: "meta-lxatac-bsp/recipes-bsp/barebox/barebox-tools.bbappend"
+    git_tag:
+      url: "https://github.com/barebox/barebox.git"
+      version_pattern: "^v([\\d+\\.]*\\d+)$"
+      version_order: semver
+    tarball:
+      url: "https://barebox.org/download/barebox-$PV.tar.bz2"
+
   - recipe: "meta-lxatac-software/recipes-devtools/github-act-runner/github-act-runner_$PV.bb"
     git_tag:
       url: "https://github.com/ChristopherHX/github-act-runner.git"

--- a/tools/update/recipes.yaml
+++ b/tools/update/recipes.yaml
@@ -56,8 +56,8 @@ recipes:
       branch: main
 
   - recipe: "meta-lxatac-software/recipes-support/imx-uuu/imx-uuu_$PV.bb"
-    git_tag:
-      url: "https://github.com/nxp-imx/mfgtools.git"
+    github_release:
+      project: "nxp-imx/mfgtools"
       version_pattern: "^uuu_([\\d+\\.]*\\d+)$"
       version_order: semver
 
@@ -67,7 +67,7 @@ recipes:
       branch: main
 
   - recipe: "meta-lxatac-software/recipes-support/bcu/bcu_%.bbappend"
-    git_tag:
-      url: "https://github.com/nxp-imx/bcu.git"
+    github_release:
+      project: "nxp-imx/bcu"
       version_pattern: "^bcu_(1\\.1[\\.\\d+]*)$"
       version_order: semver

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+import glob
+from tempfile import TemporaryDirectory
+import re
+import os.path
+import subprocess
+
+import yaml
+
+
+BRANCH_PRIORITIES = tuple(
+    (re.compile(pattern), prio)
+    for pattern, prio in (
+        ("main", 9999),
+        ("master", 9998),
+        ("release.*", 9997),
+        ("stable.*", 9996),
+        (".*release", 9995),
+        (".*stable", 9994),
+        ("bugfix.*", 6001),
+        ("hotfix.*", 6000),
+        # The default is 5000
+        ("next", 4003),
+        ("develop", 4002),
+        ("staging", 4001),
+        ("feature.*", 4000),
+        (".*/.*", 2000),
+    )
+)
+
+PATTERNS = tuple(
+    (re.compile(pattern, re.MULTILINE), replacement)
+    for pattern, replacement in (
+        (r'^PV = "(?P<needle>[^"]*)"', lambda ri: ri.get("pv")),
+        (
+            r'^SRCREV = "[^"]*(?P<needle>[0-9a-f]{40})',
+            lambda ri: ri.get("commit_hash"),
+        ),
+        (r'^SRCBRANCH = "(?P<needle>[^"]*)"', lambda ri: ri.get("branch")),
+        (
+            r"\s(?P<needle>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+\d{4})\s",
+            lambda ri: ri.get("commit_date"),
+        ),
+    )
+)
+
+
+def semver_key(info):
+    return tuple(int(n) for n in info["pv"].split("."))
+
+
+def branch_key(name):
+    """Assign a priority to a branch name
+
+    A commit will likely be contained in multiple branches and we want to use
+    the most descriptive one as SRCBRANCH in the recipes.
+    Assign priorities to common branch names based on how descriptive they are.
+    """
+
+    for pattern, prio in BRANCH_PRIORITIES:
+        if pattern.fullmatch(name):
+            return (prio, name)
+
+    return (5000, name)
+
+
+def run(cmd, capture=True):
+    stdout = subprocess.PIPE if capture else None
+    return subprocess.run(cmd, stdout=stdout, check=True, text=True).stdout
+
+
+def fetch_git_branch(info):
+    """Fetch information about the most recent commit on a git branch
+
+    This is used for _git.bb recipes.
+    """
+
+    url = info["git_branch"]["url"]
+    branch = info["git_branch"]["branch"]
+
+    with TemporaryDirectory() as dir:
+        git_dir = os.path.join(dir, "repo.git")
+
+        run(["git", "clone", "--bare", "--filter=blob:none", url, git_dir], False)
+
+        git = ["git", "-C", git_dir]
+        commit_hash = run([*git, "rev-parse", f"refs/heads/{branch}"]).strip()
+        commit_date = run([*git, "log", "-1", "--format=%ci", commit_hash]).strip()
+
+        try:
+            info["describe"] = run([*git, "describe", "--tags", branch]).strip()
+        except subprocess.CalledProcessError:
+            pass
+
+    version_pattern = info.get("version_pattern")
+    describe = info.get("describe")
+    version = (
+        re.match(version_pattern, describe)[1] if version_pattern and describe else ""
+    )
+
+    if version:
+        info["pv"] = f"{version}+git"
+
+    info["commit_hash"] = commit_hash
+    info["commit_date"] = commit_date
+
+
+def fetch_git_tag(info):
+    """Fetch information about the most recent git tag
+
+    ... that matches a version pattern and "most recent" may also not mean by
+    date but by semver.
+    """
+
+    url = info["git_tag"]["url"]
+    version_pattern = re.compile(info["git_tag"]["version_pattern"])
+
+    versions = list()
+
+    with TemporaryDirectory() as dir:
+        git_dir = os.path.join(dir, "repo.git")
+
+        run(["git", "clone", "--bare", "--filter=blob:none", url, git_dir], False)
+
+        git = ["git", "-C", git_dir]
+        tags = run([*git, "tag", "--list"]).strip()
+
+        for tag in tags.split("\n"):
+            version_match = version_pattern.match(tag)
+
+            if version_match is not None:
+                pv = version_match[1]
+                versions.append({"tag": tag, "pv": pv})
+
+        if info["git_tag"]["version_order"] == "semver":
+            # When sorting by semver we do not need to get all commit dates,
+            # only the one for the newest commit by semver in the tag name.
+            # We can thus reduce the versions dict to only one entry.
+            versions.sort(key=semver_key)
+            versions = versions[-1:]
+
+        for version in versions:
+            tag_name = version["tag"]
+
+            hash = run([*git, "rev-parse", f"refs/tags/{tag_name}^{{commit}}"]).strip()
+
+            version["commit_hash"] = hash
+            version["commit_date"] = run(
+                [*git, "log", "-1", "--format=%ci", hash]
+            ).strip()
+            version["commit_timestamp"] = int(
+                run([*git, "log", "-1", "--format=%ct", hash]).strip()
+            )
+
+            branches = run(
+                [
+                    *git,
+                    "branch",
+                    "--format=%(refname:lstrip=2)",
+                    "--contains",
+                    hash,
+                ]
+            ).strip()
+
+            version["branches"] = list(
+                branch.strip() for branch in branches.split("\n")
+            )
+            version["branch"] = max(version["branches"], key=branch_key)
+
+    # Sort the remaining candidates by date.
+    # If the version_order is semver the dict will only have one element
+    # at this point in time.
+    newest = max(versions, key=lambda version: version["commit_timestamp"])
+    info.update(newest)
+
+
+def fetch_info(recipe_info):
+    if "git_branch" in recipe_info:
+        fetch_git_branch(recipe_info)
+
+    elif "git_tag" in recipe_info:
+        fetch_git_tag(recipe_info)
+
+
+def write_recipe(recipe_info):
+    # List old recipes and read one of them
+    old_recipes = glob.glob(glob.escape(recipe_info["recipe"]).replace("$PV", "*"))
+
+    with open(old_recipes[0], "r") as fd:
+        recipe_bb = fd.read()
+
+    # Replace patterns with info from the new release
+    for pattern, replacement in PATTERNS:
+        if found := pattern.search(recipe_bb):
+            start, end = found.span("needle")
+
+            if (rep := replacement(recipe_info)) is not None:
+                recipe_bb = recipe_bb[:start] + rep + recipe_bb[end:]
+
+    # Write new recipe to disk
+    recipe_path = recipe_info["recipe"].replace("$PV", recipe_info.get("pv", ""))
+
+    with open(recipe_path, "w") as fd:
+        fd.write(recipe_bb)
+        print(f"Wrote {recipe_path}")
+
+    # Delete old recipes
+    for old_recipe in old_recipes:
+        if old_recipe != recipe_path:
+            os.remove(old_recipe)
+            print(f"Removed {old_recipe}")
+
+
+def main(argv):
+    with open(argv[1]) as fd:
+        config = yaml.safe_load(fd)
+
+    for recipe_info in config["recipes"]:
+        print(f"\n\nGenerate: {recipe_info['recipe']}")
+
+        fetch_info(recipe_info)
+        write_recipe(recipe_info)
+
+        print("done")
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv)

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from datetime import datetime
 import glob
 import hashlib
 from tempfile import TemporaryDirectory
@@ -86,6 +87,12 @@ def branch_key(name):
 def run(cmd, capture=True):
     stdout = subprocess.PIPE if capture else None
     return subprocess.run(cmd, stdout=stdout, check=True, text=True).stdout
+
+
+def get_json(url):
+    with requests.get(url, stream=True) as req:
+        req.raise_for_status()
+        return req.json()
 
 
 def fetch_git_branch(info):
@@ -193,6 +200,70 @@ def fetch_git_tag(info):
     info.update(newest)
 
 
+def fetch_github_release(recipe_info):
+    """Get information about the most recent GitHub release
+
+    This has the benefit of being able to filter out pre-releases,
+    when compared to `git_tag`.
+    """
+
+    project = recipe_info["github_release"]["project"]
+    version_pattern = re.compile(recipe_info["github_release"]["version_pattern"])
+    prereleases = recipe_info["github_release"].get("prereleases", False)
+
+    releases = get_json(f"https://api.github.com/repos/{project}/releases")
+
+    versions = list()
+
+    for release in releases:
+        # Filter out draft releases
+        if release.get("draft", False):
+            continue
+
+        # Filter out prereleases (if desired)
+        if not prereleases and release.get("prerelease", False):
+            continue
+
+        # Only keep versions that match our schema
+        version_match = version_pattern.match(release["tag_name"])
+
+        if version_match is not None:
+            versions.append(
+                {
+                    "tag": version_match[0],
+                    "pv": version_match[1],
+                }
+            )
+
+    if recipe_info["github_release"]["version_order"] == "semver":
+        versions.sort(key=semver_key)
+        versions = versions[-1:]
+
+    for version in versions:
+        tag = version["tag"]
+        tag_info = get_json(
+            f"https://api.github.com/repos/{project}/git/matching-refs/tags/{tag}"
+        )
+        commit_info = get_json(tag_info[0]["object"]["url"])
+
+        version["commit_hash"] = commit_info["sha"]
+
+        who = (
+            commit_info.get("committer")
+            or commit_info.get("author")
+            or commit_info.get("tagger")
+        )
+        commit_date = who["date"].replace("T", " ").replace("Z", " +0000")
+        version["commit_date"] = commit_date
+        version["commit_timestamp"] = datetime.fromisoformat(commit_date).timestamp()
+
+    # Sort the remaining candidates by date.
+    # If the version_order is semver the dict will only have one element
+    # at this point in time.
+    newest = max(versions, key=lambda version: version["commit_timestamp"])
+    recipe_info.update(newest)
+
+
 def fetch_tarball(recipe_info):
     """Get hash values for a release tarball
 
@@ -234,6 +305,9 @@ def fetch_info(recipe_info):
 
     elif "git_tag" in recipe_info:
         fetch_git_tag(recipe_info)
+
+    elif "github_release" in recipe_info:
+        fetch_github_release(recipe_info)
 
     # The most recent version is determined by a git strategy,
     # but for some recipes a tarball is used to actually fetch the release.

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import glob
+import hashlib
 from tempfile import TemporaryDirectory
 import re
 import os.path
 import subprocess
 
+import requests
 import yaml
 
 
@@ -41,6 +43,22 @@ PATTERNS = tuple(
         (
             r"\s(?P<needle>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+\d{4})\s",
             lambda ri: ri.get("commit_date"),
+        ),
+        (
+            r'^SRC_URI\[md5sum\] = "[^"]*(?P<needle>[0-9a-f]{32})"',
+            lambda ri: ri.get("md5sum"),
+        ),
+        (
+            r'^SRC_URI\[sha1sum\] = "[^"]*(?P<needle>[0-9a-f]{40})"',
+            lambda ri: ri.get("sha1sum"),
+        ),
+        (
+            r'^SRC_URI\[sha256sum\] = "[^"]*(?P<needle>[0-9a-f]{64})"',
+            lambda ri: ri.get("sha256sum"),
+        ),
+        (
+            r'^SRC_URI\[sha512sum\] = "[^"]*(?P<needle>[0-9a-f]{128})"',
+            lambda ri: ri.get("sha512sum"),
         ),
     )
 )
@@ -175,12 +193,53 @@ def fetch_git_tag(info):
     info.update(newest)
 
 
+def fetch_tarball(recipe_info):
+    """Get hash values for a release tarball
+
+    Some recipes use git tags to determine the most recent version,
+    but use tarballs to actually fetch the code.
+    In that case download the tarball and calculate the checksum.
+    """
+
+    url = recipe_info["tarball"]["url"]
+    url = url.replace("$PV", recipe_info.get("pv", ""))
+
+    print(f"Hashing {url}")
+
+    hashers = {
+        "md5sum": hashlib.md5(),
+        "sha1sum": hashlib.sha1(),
+        "sha256sum": hashlib.sha256(),
+        "sha512sum": hashlib.sha512(),
+    }
+
+    with requests.get(url, stream=True) as req:
+        req.raise_for_status()
+
+        for chunk in req.iter_content(chunk_size=8192):
+            print(".", end="", flush=True)
+
+            if chunk:
+                for hasher in hashers.values():
+                    hasher.update(chunk)
+
+    recipe_info.update((name, hasher.hexdigest()) for name, hasher in hashers.items())
+
+    print(" done.")
+
+
 def fetch_info(recipe_info):
     if "git_branch" in recipe_info:
         fetch_git_branch(recipe_info)
 
     elif "git_tag" in recipe_info:
         fetch_git_tag(recipe_info)
+
+    # The most recent version is determined by a git strategy,
+    # but for some recipes a tarball is used to actually fetch the release.
+    # If that is the case we need to update the hash.
+    if "tarball" in recipe_info:
+        fetch_tarball(recipe_info)
 
 
 def write_recipe(recipe_info):


### PR DESCRIPTION
I have tried basically the same before in the form of #296.
But that approach did not receive much love from anyone but me, partly because it required invasive changes to the existing bitbake files.

I did however happily use the script and GitHub magic in the background to be notified about package upgrades.

Using the auto-updater for notifications but having to hand-craft PRs anyways is a bit of duplicate work and means that I can not be the one reviewing the changes. So I would prefer having the automation right here in this repo.

I have changed the implementation so that it no longer requires any changes to our existing recipes in the hopes of making it more acceptable this way.

A PR generated by this script looks something like this: https://github.com/hnez/meta-lxatac/pull/25.