### PR TITLE
dependabot / meta-ptx: whinlatter followup fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,13 @@ updates:
   - package-ecosystem: gitsubmodule
     directory: "/"
     commit-message:
-      prefix: "meta-*: "
+      prefix: "yocto: "
     schedule:
       interval: "weekly"
       day: "thursday"
     groups:
       layers:
         patterns:
+          - "bitbake"
+          - "openembedded-core"
           - "meta-*"
-          - "poky"

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "meta-ptx"]
 	path = meta-ptx
 	url = https://github.com/pengutronix/meta-ptx.git
-	branch = master
+	branch = whinlatter
 [submodule "meta-oe"]
 	path = meta-oe
 	url = https://github.com/openembedded/meta-openembedded.git


### PR DESCRIPTION
We want Dependabot to update all layers in a single pull request and not as seen in #332 and #333 in separate PRs.
Fix that.

---

The meta-ptx repository now has a whinlatter branch. Use that.
Thanks to @ejoerns for noticing.