### PR TITLE
software: distro: tacos: choose avahi as libnss-mdns provider

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -73,3 +73,7 @@ BB_HASHSERVE ??= "auto"
 
 # recommend ipk package management - make sure to comment or set it in local.conf.sample
 PACKAGE_CLASSES ?= "package_ipk"
+
+# There are two providers for libnss-mdns: avahi-libnss-mdns and mdns.
+# The former is in oe-core and the latter in meta-oe. Choose the former.
+PREFERRED_RPROVIDER_libnss-mdns = "avahi-libnss-mdns"


### PR DESCRIPTION
There are two providers for libnss-mdns: avahi-libnss-mdns and mdns. The former is in oe-core and the latter in meta-oe. Choose the former.

---

Note: this PR used to also contain a commit that updates the Github Actions used, but that has been solved by #358.