### PR TITLE
ci: build: archive SBOM and VEX information for every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,3 +93,11 @@ jobs:
         with:
           name: images
           path: images/*.desktop
+
+      - name: Upload Software Bill of Materials to GitHub
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: |
+            images/lxatac-core-image-base-lxatac.rootfs.json
+            images/lxatac-core-image-base-lxatac.rootfs.spdx.json

--- a/meta-lxatac-bsp/recipes-kernel/linux/linux-lxatac.bb
+++ b/meta-lxatac-bsp/recipes-kernel/linux/linux-lxatac.bb
@@ -18,6 +18,10 @@ S = "${UNPACKDIR}/linux-${LINUX_VERSION}"
 
 COMPATIBLE_MACHINE = "lxatac"
 
+# Track which files are compiled in so we can ignore CVEs that only
+# affect files we do not build.
+SPDX_INCLUDE_COMPILED_SOURCES = "1"
+
 # The coreutils-native dependency is required since kernel 6.11,
 # which uses the `truncate` tool in a script.
 # It can likely be removed again once the kernel.bbclass is updated.

--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -57,8 +57,11 @@ require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/security_flags.inc
 INHERIT += "uninative"
 
-# Enable creation of SPDX manifests
-INHERIT += "create-spdx"
+# Enable creation of SPDX manifests and vulnerability exploitability
+# exchange files.
+# Exclude CVEs that are known to not affect yocto.
+require conf/distro/include/cve-extra-exclusions.inc
+INHERIT += "create-spdx vex"
 
 # Create a directory for each package in `/usr/share/licenses`
 # and place licensing information there.


### PR DESCRIPTION
This is a subset of #338 that only generates and uploads the SBOM data, but does not do anything with it yet.
Getting this merged before #338 should allow us to experiment more.