### PR TITLE
ci: build: do not rebuild on a schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - whinlatter
       - stable-*
-  schedule:
-    - cron: '10 21 * * 4'
 
 jobs:
   build:


### PR DESCRIPTION
The meta-lxatac build is deterministic in the sense that a meta-lxatac commit fully describes the state of all submodules and all recipes in meta-lxatac and the submodules.

This is different to some other layer build scripts where we build against the most recent upstream bitbake, openembedded-core and meta-* layers.

For thos it makes sense to rebuild on a schedule. For meta-lxatac however? Not so much.