### PR TITLE
dependabot: also update the GitHub actions used

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,13 @@ updates:
           - "bitbake"
           - "openembedded-core"
           - "meta-*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
We have started to get warnings about outdated actions maybe not working anymore at some future day.
Make sure that does not happen by regularly updating the actions versions.