### PR TITLE
software: systemd: disable osc-context feature

### DIFF
--- a/meta-lxatac-software/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lxatac-software/recipes-core/systemd/systemd_%.bbappend
@@ -6,5 +6,6 @@ PACKAGECONFIG:append = " \
 "
 
 PACKAGECONFIG:remove = " \
+  osc-context \
   vconsole \
 "


### PR DESCRIPTION
The OSC 3008 standard injects control characters into the terminal output at certain context changes, i.e. when a system is booted and waits for a login.

This currently messes with our labgrid tests and we do not need it.

Disable the feature

[1]: https://uapi-group.org/specifications/specs/osc_context/