### PR TITLE
meta-lxatac-software: distro: tacos: update version to v26.07

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "25.09+dev"
+DISTRO_VERSION = "26.07"
 DISTRO_CODENAME = "tacos-wrynose"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
It's time to spin a new release.

Notable Changes since v25.09:

  - Change how polling for software updates works. Polling is now handled by the new polling support in RAUC, instead of the tacd. This also enables (optional) support for automatic updates.
  - Implementation of strict CVE vulnerability tracking in preparation for the european cyber resiliance act.
  - A labgrid coordinator is now installed on the TAC but not enabled by default.
  - Update from yocto whinlatter to wrynose.
  - Update from Linux version 6.17 to 7.1.
  - Update from barebox 2025.09 to 2026.06.1.
  - Update various pieces of included software.