### PR TITLE
meta-lxatac-software: distro: tacos: start v26.07 devel phase

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "26.07"
+DISTRO_VERSION = "26.07-dev"
 DISTRO_CODENAME = "tacos-wrynose"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
Now that we have a v26.07 stable release we need to start denoting everything based on it as +dev again.

TODO before merging:

- [ ] Publish v26.07 stable release