### PR TITLE
software: openssh: prevent password based authentication

### DIFF
--- a/meta-lxatac-software/recipes-core/openssh/openssh/20-disallow-password.conf
+++ b/meta-lxatac-software/recipes-core/openssh/openssh/20-disallow-password.conf
@@ -1,0 +1,1 @@
+PasswordAuthentication no

--- a/meta-lxatac-software/recipes-core/openssh/openssh_%.bbappend
+++ b/meta-lxatac-software/recipes-core/openssh/openssh_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/openssh:"
+
+SRC_URI += "file://20-disallow-password.conf"
+
+do_install:append() {
+    install -D -m 0644 ${UNPACKDIR}/20-disallow-password.conf \
+        ${D}${sysconfdir}/ssh/sshd_config.d/20-disallow-password.conf
+}
+


### PR DESCRIPTION
As part of our cyber security risk assessment we have decided against allowing password based authentication on the TAC. Public key authentication is the way to go.