### PR TITLE
ci: sbom-cve-check: use commandline to download job artifacts

### DIFF
--- a/.github/workflows/sbom-cve-check.yml
+++ b/.github/workflows/sbom-cve-check.yml
@@ -2,7 +2,7 @@ name: sbom-cve-check
 
 on:
   workflow_call:
-    inputs:
+    inputs: &workflow-inputs
       run-id:
         required: false
         default: ""
@@ -11,6 +11,8 @@ on:
         required: false
         default: ""
         type: string
+  workflow_dispatch:
+    inputs: *workflow-inputs
 
 jobs:
   check:

--- a/.github/workflows/sbom-cve-check.yml
+++ b/.github/workflows/sbom-cve-check.yml
@@ -42,10 +42,7 @@ jobs:
         if: ${{ inputs.release != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download \
-            "${{ inputs.release }}" \
-            --pattern lxatac-core-image-base-lxatac.rootfs*.json
+        run: gh release download "${{ inputs.release }}" --pattern "*.json"
 
       - name: "Run sbom-cve-check"
         run: |

--- a/.github/workflows/sbom-cve-check.yml
+++ b/.github/workflows/sbom-cve-check.yml
@@ -34,10 +34,9 @@ jobs:
 
       - name: "Download SBOM information from run ${{ inputs.run-id || github.run_id }}"
         if: ${{ inputs.release == '' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: sbom
-          run-id: ${{ inputs.run-id || github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download --name sbom "${{ inputs.run-id || github.run_id }}"
 
       - name: "Download SBOM information from release ${{ inputs.release }}"
         if: ${{ inputs.release != '' }}


### PR DESCRIPTION
For some reason download-artifact does not work when running against an old run. Maybe the CLI works better.