### PR TITLE
ci: rerun-cve-check: create annotation update PR when done

### DIFF
--- a/.github/workflows/rerun-cve-check.yml
+++ b/.github/workflows/rerun-cve-check.yml
@@ -50,3 +50,56 @@ jobs:
     uses: ./.github/workflows/sbom-cve-check.yml
     with:
       release: ${{ needs.targets.outputs.release-tag }}
+
+  pull-request:
+    name: Update Annotations via PR
+    runs-on: ubuntu-latest
+    needs: [current-build-check, current-release-check]
+    if: ${{ always() }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+
+      - name: Configure git
+        run: |
+          git config user.email "info@linux-automation.com"
+          git config user.name "CVE Annotation Updater Bot"
+
+      - name: Create a new branch
+        run: git checkout -b "update/cve-$(date +%Y%m%d)"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cve-check-stable
+          path: stable
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cve-check-latest
+          path: latest
+
+      - name: Generate new annotations
+        run: |
+          python3 tools/cve/cve_whatever.py \
+            stable/cve-check-linux-no-annot.json \
+            latest/cve-check-linux-no-annot.json
+
+      - name: Commit changes to annotations
+        id: annotation-commit
+        run: |
+          git add tools/cve/annotations
+          git commit --signoff --message="CVE Annotation updates for $(date +%Y-%m-%d)"
+        continue-on-error: true
+
+      - name: Push changes upstream
+        if: ${{ steps.annotation-commit.outcome == 'success' }}
+        run: git push --set-upstream origin "$(git branch --show-current)"
+
+      - name: Create pull request
+        if: ${{ steps.annotation-commit.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr create --base "${{ github.ref_name }}" --fill-first --draft

--- a/.github/workflows/sbom-cve-check.yml
+++ b/.github/workflows/sbom-cve-check.yml
@@ -57,6 +57,14 @@ jobs:
               "obsolete_assessment_check=True" \
             --export-type yocto-cve-check-manifest --export-path cve-check.json
 
+      - name: "Run sbom-cve-check (without our annotations)"
+        run: |
+          sbom-cve-check \
+            --verbose \
+            --sbom-path lxatac-core-image-base-lxatac.rootfs.spdx.json \
+            --yocto-vex-manifest lxatac-core-image-base-lxatac.rootfs.vex.json \
+            --export-type yocto-cve-check-manifest --export-path cve-check-no-annot.json
+
       - name: "Filter CVEs based on kernel version and compiled files"
         run: |
           ./openembedded-core/scripts/contrib/improve_kernel_cve_report.py \
@@ -65,16 +73,24 @@ jobs:
             --old-cve-report cve-check.json \
             --new-cve-report cve-check-linux.json
 
+          ./openembedded-core/scripts/contrib/improve_kernel_cve_report.py \
+            --spdx build-linux-lxatac.spdx.json \
+            --datadir vulns \
+            --old-cve-report cve-check-no-annot.json \
+            --new-cve-report cve-check-linux-no-annot.json
+
       - name: "Generate HTML summary"
         run: python3 tools/cve/cve_to_html.py < cve-check-linux.json > cve-check.html
 
       - name: "Upload Artifacts to GitHub"
         uses: actions/upload-artifact@v7
         with:
-          name: cve-check
+          name: cve-check-${{ inputs.release != '' && 'stable' || 'latest' }}
           path: |
             cve-check.json
             cve-check-linux.json
+            cve-check-no-annot.json
+            cve-check-linux-no-annot.json
             cve-check.html
 
       - name: "Generate text summary"


### PR DESCRIPTION
This will open a Draft PR like this one https://github.com/linux-automation/meta-lxatac/pull/385 whenever a CVE check was performed.

These Draft PRs can obviously not be merged as is, because proper annotations have to be made by a human and in some cases we may also have to add backports instead of just arguing why a CVE does not affect us.

This nevertheless makes my life easier, because in the ideal case I just have to update the annotations, force-push and be done with it.