### PR TITLE
software: distro: tacos: fix wrong `+dev` separator in DISTRO_VERSION

### DIFF
--- a/meta-lxatac-software/conf/distro/tacos.conf
+++ b/meta-lxatac-software/conf/distro/tacos.conf
@@ -1,6 +1,6 @@
 DISTRO = "tacos"
 DISTRO_NAME = "TAC OS - The LXA TAC operating system"
-DISTRO_VERSION = "26.07-dev"
+DISTRO_VERSION = "26.07+dev"
 DISTRO_CODENAME = "tacos-wrynose"
 
 MAINTAINER = "Linux Automation GmbH <info@linux-automation.com>"


### PR DESCRIPTION
We use `+dev` to indicate dev releases. Not `-dev`.

Fixes: 74802e18 ("meta-lxatac-software: distro: tacos: start v26.07 devel phase")