### PR TITLE
meta-lxatac-software: rauc: Migrate labgrid-coordiantor State

### DIFF
--- a/meta-lxatac-software/recipes-core/bundles/files/hook.sh
+++ b/meta-lxatac-software/recipes-core/bundles/files/hook.sh
@@ -95,6 +95,7 @@ case "$1" in
 		migrate /home/root/.bash_history
 		migrate /home/root/.ssh/authorized_keys
 		migrate /var/cache/lxa-iobus/lss-cache
+		migrate /etc/systemd/system/multi-user.target.wants/labgrid-coordinator.service
 
 		# Also allow the running system to specify additional files to
 		# migrate to the new slot via files in /etc/rauc/migrate.d.


### PR DESCRIPTION
Since some time we ship all the prerequisites to use the LXA TAC as a labrid-coordinator.

In case a user enables the labgrid-coordinator systemd-service migrate this activation into the new system during an update.