### PR TITLE
CI: Let codespell run on everything and use ruff to format and lint Python code

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = npm-shrinkwrap.json,*.pem,*.patch
+skip = npm-shrinkwrap.json,*.pem,*.patch,bitbake,meta-arm,meta-labgrid,meta-oe,meta-ptx,meta-rauc,meta-selinux,meta-virtualization,openembedded-core
 ignore-words-list = crate,ratatui

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: python3 -m pip install codespell
-      - run: codespell meta-lxatac-bsp meta-lxatac-software .github oe-init-build-env README.md
+      - run: codespell .

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,17 @@
+name: ruff
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '10 21 * * 4'
+
+jobs:
+  ruff:
+    name: Python Format and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: python3 -m pip install ruff
+      - run: ruff format --check
+      - run: ruff check

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,13 @@
+line-length = 119
+exclude = [
+    "bitbake",
+    "meta-arm",
+    "meta-labgrid",
+    "meta-oe",
+    "meta-ptx",
+    "meta-rauc",
+    "meta-selinux",
+    "meta-virtualization",
+    "openembedded-core",
+]
+lint.select = ["B", "E", "F", "I", "SIM"]

--- a/tools/cve/annotations/CVE-2019-14899.json
+++ b/tools/cve/annotations/CVE-2019-14899.json
@@ -85,7 +85,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "This issue regards the possibility of infering information about traffic in a VPN on various operating systems. Nothing that concerns us much.",
+      "status_notes": "This issue regards the possibility of inferring information about traffic in a VPN on various operating systems. Nothing that concerns us much.",
       "vulnerability": {
         "name": "CVE-2019-14899"
       }

--- a/tools/cve/annotations/CVE-2021-3864.json
+++ b/tools/cve/annotations/CVE-2021-3864.json
@@ -85,7 +85,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "This vulnerability requires an elaborate setup of coredumping setuid programs. On the TAC everything runs as root, so this does not affect us. The Debian Security tracker has choosen not to do anything about this as well.",
+      "status_notes": "This vulnerability requires an elaborate setup of coredumping setuid programs. On the TAC everything runs as root, so this does not affect us. The Debian Security tracker has chosen not to do anything about this as well.",
       "vulnerability": {
         "name": "CVE-2021-3864"
       }

--- a/tools/cve/annotations/CVE-2022-4543.json
+++ b/tools/cve/annotations/CVE-2022-4543.json
@@ -85,7 +85,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "This vulnerarbility only affects Intel systems",
+      "status_notes": "This vulnerability only affects Intel systems",
       "vulnerability": {
         "name": "CVE-2022-4543"
       }

--- a/tools/cve/annotations/CVE-2026-48618.json
+++ b/tools/cve/annotations/CVE-2026-48618.json
@@ -15,7 +15,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Exploting this issue requires specially crafted (publicly trusted) TLS certificates",
+      "status_notes": "Exploiting this issue requires specially crafted (publicly trusted) TLS certificates",
       "vulnerability": {
         "name": "CVE-2026-48618"
       }

--- a/tools/cve/annotations/CVE-2026-48930.json
+++ b/tools/cve/annotations/CVE-2026-48930.json
@@ -15,7 +15,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Exploting this vulnerability would require crafted TLS certificates which no issuer should sign",
+      "status_notes": "Exploiting this vulnerability would require crafted TLS certificates which no issuer should sign",
       "vulnerability": {
         "name": "CVE-2026-48930"
       }

--- a/tools/cve/annotations/CVE-2026-48931.json
+++ b/tools/cve/annotations/CVE-2026-48931.json
@@ -15,7 +15,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "A HTTP client library accepting a server 'response' that was recieved before the client sent a request does not sound like a vulnerability to me",
+      "status_notes": "A HTTP client library accepting a server 'response' that was received before the client sent a request does not sound like a vulnerability to me",
       "vulnerability": {
         "name": "CVE-2026-48931"
       }

--- a/tools/cve/annotations/CVE-2026-48934.json
+++ b/tools/cve/annotations/CVE-2026-48934.json
@@ -15,7 +15,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Exploting this vulnerability would require a very specific setup which is unlikely to be practical for an attacker",
+      "status_notes": "Exploiting this vulnerability would require a very specific setup which is unlikely to be practical for an attacker",
       "vulnerability": {
         "name": "CVE-2026-48934"
       }

--- a/tools/cve/annotations/CVE-2026-58040.json
+++ b/tools/cve/annotations/CVE-2026-58040.json
@@ -15,7 +15,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "This concerns an imcomplete fix for a TLS session reuse issue. This is very unlikely to affect us.",
+      "status_notes": "This concerns an incomplete fix for a TLS session reuse issue. This is very unlikely to affect us.",
       "vulnerability": {
         "name": "CVE-2026-58040"
       }

--- a/tools/cve/annotations/CVE-2026-5928.json
+++ b/tools/cve/annotations/CVE-2026-5928.json
@@ -10,7 +10,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Exploting this CVE requires very specific character sets to be used. It is unlikely that this is exploitable remotely on the TAC",
+      "status_notes": "Exploiting this CVE requires very specific character sets to be used. It is unlikely that this is exploitable remotely on the TAC",
       "vulnerability": {
         "name": "CVE-2026-5928"
       }

--- a/tools/cve/annotations/CVE-2026-6253.json
+++ b/tools/cve/annotations/CVE-2026-6253.json
@@ -35,7 +35,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "This issue describes a theoretical attack where credentials are passed to the wrong proxy, when multiple are configured. This is unlikely to occure on the TAC",
+      "status_notes": "This issue describes a theoretical attack where credentials are passed to the wrong proxy, when multiple are configured. This is unlikely to occur on the TAC",
       "vulnerability": {
         "name": "CVE-2026-6253"
       }

--- a/tools/cve/common.py
+++ b/tools/cve/common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from jinja2 import Template, StrictUndefined
+from jinja2 import StrictUndefined, Template
 
 
 def filter_and_sort_packages(manifest):

--- a/tools/cve/common.py
+++ b/tools/cve/common.py
@@ -14,9 +14,7 @@ def filter_and_sort_packages(manifest):
                 continue
 
             score_strs = list(
-                issue[v]
-                for v in ("scorev2", "scorev3", "scorev4")
-                if v in issue and issue[v] != "0.0"
+                issue[v] for v in ("scorev2", "scorev3", "scorev4") if v in issue and issue[v] != "0.0"
             ) + ["0.0"]
             major, minor = score_strs[0].split(".")
             issue["score"] = int(major) * 10 + int(minor)
@@ -37,9 +35,7 @@ def filter_and_sort_packages(manifest):
 
 
 def render(packages, template):
-    template = Template(
-        template, undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True
-    )
+    template = Template(template, undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
     output = template.render(packages=packages).strip() + "\n"
 
     return output

--- a/tools/cve/cve_to_html.py
+++ b/tools/cve/cve_to_html.py
@@ -64,9 +64,13 @@ TEMPLATE = """
                 <div><strong>Description:</strong> {{ issue.description | striptags | escape }}</div>
                 <div class="meta"><strong>Vector String:</strong> {{ issue.vectorString | escape }}</div>
                 {% if package.name == "linux-lxatac" %}
-                  <div><a href="https://kernel-team.pages.debian.net/kernel-sec/{{ issue.id | escape }}.html">Debian Kernel Security Tracker</a></div>
+                  <div><a href="https://kernel-team.pages.debian.net/kernel-sec/{{ issue.id | escape }}.html">
+                    Debian Kernel Security Tracker
+                  </a></div>
                 {% endif %}
-                <div><a href="https://security-tracker.debian.org/tracker/{{ issue.id | escape }}">Debian Security Tracker</a></div>
+                <div><a href="https://security-tracker.debian.org/tracker/{{ issue.id | escape }}">
+                  Debian Security Tracker
+                </a></div>
               </td>
             </tr>
           {% endfor %}

--- a/tools/cve/cve_whatever.py
+++ b/tools/cve/cve_whatever.py
@@ -73,11 +73,11 @@ def main(*manifest_paths):
 
             annotation = {}
 
-            # Check if we had an annotation for this vulnerarbility before
+            # Check if we had an annotation for this vulnerability before
             with suppress(FileNotFoundError), open(annot_old_path) as fd:
                 annotation = json.load(fd)
 
-            # Check if we alrady touched the annotation this time around
+            # Check if we already touched the annotation this time around
             with suppress(FileNotFoundError), open(annot_path) as fd:
                 annotation = json.load(fd)
 

--- a/tools/cve/cve_whatever.py
+++ b/tools/cve/cve_whatever.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-from contextlib import suppress
 import datetime
 import json
 import os
 import subprocess
 import sys
+from contextlib import suppress
 
 import common
 

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -72,7 +72,7 @@ def semver_key(info):
 def branch_key(name):
     """Assign a priority to a branch name
 
-    A commit will likely be contained in multiple branches and we want to use
+    A commit will likely be contained in multiple branches, and we want to use
     the most descriptive one as SRCBRANCH in the recipes.
     Assign priorities to common branch names based on how descriptive they are.
     """
@@ -148,7 +148,7 @@ class GitRepo:
     def refs(self):
         if self._refs is None:
             # Use the local clone for information if there is one.
-            # Oterwise ask the server for a list of refs.
+            # Otherwise, ask the server for a list of refs.
             ref_list = (
                 self._git("show-ref")
                 if self._git_dir is not None

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
-from datetime import datetime
 import glob
 import hashlib
-from tempfile import TemporaryDirectory
-import re
 import os.path
+import re
 import subprocess
+from datetime import datetime
+from tempfile import TemporaryDirectory
 
 import requests
 import yaml
-
 
 BRANCH_PRIORITIES = tuple(
     (re.compile(pattern), prio)
@@ -134,7 +133,7 @@ class GitRepo:
             return {"commit_hash": self.refs().get(commit, commit)}
 
         else:
-            git_format, fields = zip(*self.LOG_FORMAT)
+            git_format, fields = zip(*self.LOG_FORMAT, strict=True)
             res = self._git("log", "-1", f"--format={'%x00'.join(git_format)}", commit)
 
             return dict(zip(fields, res.split("\x00"), strict=True))
@@ -418,7 +417,7 @@ def main(argv):
         if "recipe" in recipe_info:
             recipes.append(recipe_info["recipe"])
 
-        print(f"\n\nGenerate:", " ".join(recipes))
+        print("\n\nGenerate:", " ".join(recipes))
 
         fetch_info(recipe_info)
 

--- a/tools/update/update.py
+++ b/tools/update/update.py
@@ -159,9 +159,7 @@ class GitRepo:
         return self._refs
 
     def refs_with_prefix(self, prefix):
-        return list(
-            ref.removeprefix(prefix) for ref in self.refs() if ref.startswith(prefix)
-        )
+        return list(ref.removeprefix(prefix) for ref in self.refs() if ref.startswith(prefix))
 
     def branches(self):
         return self.refs_with_prefix("refs/heads/")
@@ -195,9 +193,7 @@ def fetch_git_branch(info):
 
     version_pattern = info.get("version_pattern")
     describe = info.get("describe")
-    version = (
-        re.match(version_pattern, describe)[1] if version_pattern and describe else ""
-    )
+    version = re.match(version_pattern, describe)[1] if version_pattern and describe else ""
 
     if version:
         info["pv"] = f"{version}+git"
@@ -285,18 +281,12 @@ def fetch_github_release(recipe_info):
 
     for version in versions:
         tag = version["tag"]
-        tag_info = get_json(
-            f"https://api.github.com/repos/{project}/git/matching-refs/tags/{tag}"
-        )
+        tag_info = get_json(f"https://api.github.com/repos/{project}/git/matching-refs/tags/{tag}")
         commit_info = get_json(tag_info[0]["object"]["url"])
 
         version["commit_hash"] = commit_info["sha"]
 
-        who = (
-            commit_info.get("committer")
-            or commit_info.get("author")
-            or commit_info.get("tagger")
-        )
+        who = commit_info.get("committer") or commit_info.get("author") or commit_info.get("tagger")
         commit_date = who["date"].replace("T", " ").replace("Z", " +0000")
         version["commit_date"] = commit_date
         version["commit_timestamp"] = datetime.fromisoformat(commit_date).timestamp()
@@ -370,11 +360,7 @@ def get_old_recipes(recipe):
     recipe_regex = re.escape(recipe).replace("\\$PV", "[\\d+\\.]*\\d+")
     recipe_regex = re.compile(recipe_regex)
 
-    return list(
-        old_recipe
-        for old_recipe in glob.glob(recipe_glob)
-        if recipe_regex.fullmatch(old_recipe)
-    )
+    return list(old_recipe for old_recipe in glob.glob(recipe_glob) if recipe_regex.fullmatch(old_recipe))
 
 
 def write_recipe(recipe, recipe_info):


### PR DESCRIPTION
This PR does two things:

1) Fix typos in the repository and configure to run `codespell` und everything but a list of exceptions.
2) Lint and format existing Python-code using `ruff` and add a CI workflow to ensure linting and formatting.