### PR TITLE
ci: rerun-cve-check: run cve check against last completed build job

### DIFF
--- a/.github/workflows/rerun-cve-check.yml
+++ b/.github/workflows/rerun-cve-check.yml
@@ -25,7 +25,7 @@ jobs:
             --workflow build \
             --event push \
             --branch "${GITHUB_REF_NAME}" \
-            --status success \
+            --status completed \
             --json databaseId --jq ".[0].databaseId" \
           )" | tee -a "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sbom-cve-check.yml
+++ b/.github/workflows/sbom-cve-check.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v7
+        with:
+          ref: "${{ github.event.repository.default_branch }}"
 
       - name: "Install sbom-cve-check"
         run: python3 -m pip install "sbom-cve-check[extra]"


### PR DESCRIPTION
… Instead of the last successful build job.

As part of the build job sbom-cve-check is run. This usually fails, because there are nearly always some open CVEs.
This marks the whole build job as failed.

Take this run for example [31157259096](https://github.com/linux-automation/meta-lxatac/actions/runs/31157259096).
It determined that [29472301968](https://github.com/linux-automation/meta-lxatac/actions/runs/29472301968) was the most recent successful build - even though it is three weeks old and we have far more recent builds with failed CVE checks.

This means the last successful build job (including a successful CVE check) will usually be quite old and not what we want to re-run the CVE check against. Instead we want the most recent completed build job - even if it failed.

---

The other commit is not too relevant when running on the default branch but is relevant when running on a stable branch, where we would however like to use the most recent CVE annotations from the default branch instead of the old ones from the stable branch.